### PR TITLE
Sprint 106.1 - fix taoQtiTest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     }
   ],
   "keywords": [
-    "sprint 106",
+    "sprint 106.1",
     "tao",
     "oat",
     "computer-based-assessment"
@@ -45,7 +45,7 @@
     "oat-sa/extension-tao-itemqti-pic": "5.3.1",
     "oat-sa/extension-tao-test": "12.1.0",
     "oat-sa/extension-tao-testlinear": "3.2.1",
-    "oat-sa/extension-tao-testqti": "33.10.1",
+    "oat-sa/extension-tao-testqti": "33.10.2",
     "oat-sa/extension-tao-outcome": "9.2.1",
     "oat-sa/extension-tao-outcomeui": "7.11.0",
     "oat-sa/extension-tao-outcomerds": "6.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "842d8c8edea9a1708b4ed42ad65bbb8a",
+    "content-hash": "fee0f232964994d98652a9e3107f0944",
     "packages": [
         {
             "name": "clearfw/clearfw",
@@ -3045,16 +3045,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti",
-            "version": "v33.10.1",
+            "version": "v33.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "0b2493be3d0ac693a5c3049c293ddb2cce4bc2fc"
+                "reference": "03f68e4a85998ef3468a9946bf2fda4c2186354a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/0b2493be3d0ac693a5c3049c293ddb2cce4bc2fc",
-                "reference": "0b2493be3d0ac693a5c3049c293ddb2cce4bc2fc",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/03f68e4a85998ef3468a9946bf2fda4c2186354a",
+                "reference": "03f68e4a85998ef3468a9946bf2fda4c2186354a",
                 "shasum": ""
             },
             "require": {
@@ -3119,7 +3119,7 @@
                 "TAO",
                 "computer-based-assessment"
             ],
-            "time": "2019-07-05T09:19:20+00:00"
+            "time": "2019-07-08T07:27:53+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",


### PR DESCRIPTION
Sprint 106.1

**Release notes :**
 - _Fix_ [NEX-19](https://oat-sa.atlassian.net/browse/NEX-19) : update the provider with a wrong bundle [#1544](https://github.com/oat-sa/extension-tao-testqti/pull/1544) ( by [krampstudio](https://github.com/krampstudio) - validated by [btamas](https://github.com/btamas) )
