### PR TITLE
Release sprint 109 update 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "oat-sa/extension-tao-outcome": "9.3.0",
     "oat-sa/extension-tao-outcomeui": "7.11.3",
     "oat-sa/extension-tao-outcomerds": "6.1.1",
-    "oat-sa/extension-tao-outcomekeyvalue": "5.3.0",
+    "oat-sa/extension-tao-outcomekeyvalue": "5.3.1",
     "oat-sa/extension-tao-outcomelti": "3.1.8",
     "oat-sa/extension-tao-delivery": "14.1.0",
     "oat-sa/extension-tao-delivery-rdf": "8.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "586a52992ae0a47b6a3e9db410b1b3d3",
+    "content-hash": "da19a1ae4e21e21d41b0119e742c7f0f",
     "packages": [
         {
             "name": "clearfw/clearfw",
@@ -2436,16 +2436,16 @@
         },
         {
             "name": "oat-sa/extension-tao-outcomekeyvalue",
-            "version": "v5.3.0",
+            "version": "v5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-outcomekeyvalue.git",
-                "reference": "82698f77f1c3a3b57e7b82b3b22bc8780b7264fc"
+                "reference": "cdbeb2c19c431b5956a79394e4f48c573e62d413"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-outcomekeyvalue/zipball/82698f77f1c3a3b57e7b82b3b22bc8780b7264fc",
-                "reference": "82698f77f1c3a3b57e7b82b3b22bc8780b7264fc",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-outcomekeyvalue/zipball/cdbeb2c19c431b5956a79394e4f48c573e62d413",
+                "reference": "cdbeb2c19c431b5956a79394e4f48c573e62d413",
                 "shasum": ""
             },
             "require": {
@@ -2509,7 +2509,7 @@
                 "TAO",
                 "computer-based-assessment"
             ],
-            "time": "2019-08-02T09:10:51+00:00"
+            "time": "2019-08-21T15:32:07+00:00"
         },
         {
             "name": "oat-sa/extension-tao-outcomelti",


### PR DESCRIPTION
- [#48](https://github.com/oat-sa/extension-tao-outcomekeyvalue/pull/48) Fix version of required `generis` version in `taoAltResultStorage`