### PR TITLE
Version 0.106.2.7-alpha backport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "oat-sa/extension-tao-mediamanager": "8.0.0",
     "oat-sa/extension-pcisample": "2.4.0",
     "oat-sa/extension-tao-backoffice": "4.0.0",
-    "oat-sa/extension-tao-proctoring": "16.3.0",
+    "oat-sa/extension-tao-proctoring": "16.3.1",
     "oat-sa/extension-tao-clientdiag": "6.0.3",
     "oat-sa/extension-tao-eventlog": "2.4.0",
     "oat-sa/extension-tao-task-queue": "3.3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "09aac392b189a9715546af408e3223d0",
+    "content-hash": "c86c4b00e85db373b2fa5387255aee5f",
     "packages": [
         {
             "name": "clearfw/clearfw",
@@ -2787,16 +2787,16 @@
         },
         {
             "name": "oat-sa/extension-tao-proctoring",
-            "version": "v16.3.0",
+            "version": "v16.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-proctoring.git",
-                "reference": "9a91009790b95c397ec4cec4e5a2452b2ba87003"
+                "reference": "2af802c4fba72e1bbf6469164028030d04464f43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-proctoring/zipball/9a91009790b95c397ec4cec4e5a2452b2ba87003",
-                "reference": "9a91009790b95c397ec4cec4e5a2452b2ba87003",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-proctoring/zipball/2af802c4fba72e1bbf6469164028030d04464f43",
+                "reference": "2af802c4fba72e1bbf6469164028030d04464f43",
                 "shasum": ""
             },
             "require": {
@@ -2827,7 +2827,7 @@
                 "TAO",
                 "computer-based-assessment"
             ],
-            "time": "2019-07-05T08:54:26+00:00"
+            "time": "2019-09-10T14:58:26+00:00"
         },
         {
             "name": "oat-sa/extension-tao-revision",


### PR DESCRIPTION
Version 0.106.2.7-alpha
 
**Backport :**
- [fix] [TAO-9100](https://oat-sa.atlassian.net/browse/TAO-9100) "Started at" filter doesn't work on proctoring screen [#732](https://github.com/oat-sa/extension-tao-proctoring/pull/732)