### PR TITLE
Update oat-sa/extension-tao-testqti to v40.3.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "oat-sa/extension-tao-itemqti": "25.18.1",
     "oat-sa/extension-tao-itemqti-pic": "5.6.5",
     "oat-sa/extension-tao-test": "14.6.0",
-    "oat-sa/extension-tao-testqti": "40.3.10",
+    "oat-sa/extension-tao-testqti": "40.3.12",
     "oat-sa/extension-tao-outcome": "12.3.1",
     "oat-sa/extension-tao-outcomeui": "9.5.0",
     "oat-sa/extension-tao-outcomerds": "7.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f4e863828b919718e355f298dd5a9e4",
+    "content-hash": "1b64543da77690777750f2cc2d831933",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3828,16 +3828,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti",
-            "version": "v40.3.10",
+            "version": "v40.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "6ddd8c4f268dd5b4bb015ae5134f41ad9f62b91e"
+                "reference": "68731a199abe4fc512178412f89c67705b672c98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/6ddd8c4f268dd5b4bb015ae5134f41ad9f62b91e",
-                "reference": "6ddd8c4f268dd5b4bb015ae5134f41ad9f62b91e",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/68731a199abe4fc512178412f89c67705b672c98",
+                "reference": "68731a199abe4fc512178412f89c67705b672c98",
                 "shasum": ""
             },
             "require": {
@@ -3910,7 +3910,7 @@
                 "TAO",
                 "computer-based-assessment"
             ],
-            "time": "2021-01-06T15:45:08+00:00"
+            "time": "2021-01-20T12:44:17+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",


### PR DESCRIPTION
**Release notes :**
 - _Fix_ [TR-422](https://oat-sa.atlassian.net/browse/TR-422) : announce flagged items in the end test warning [#1964](https://github.com/oat-sa/extension-tao-testqti/pull/1964) ( by [jsconan](https://github.com/jsconan) - validated by [meefox](https://github.com/meefox) )
