### PR TITLE
Release v0.149.1-alpha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,6 @@
 {
   "name": "oat-sa/tao-community",
   "license": "GPL-2.0-only",
-  "require-dev": {
-  },
   "config": {
     "preferred-install": "dist"
   },
@@ -36,7 +34,7 @@
     "oat-sa/extension-tao-group": "7.0.0",
     "oat-sa/extension-tao-item": "11.0.0",
     "oat-sa/extension-tao-itemqti-pci": "7.0.0",
-    "oat-sa/extension-tao-itemqti": "27.1.0",
+    "oat-sa/extension-tao-itemqti": "27.1.1",
     "oat-sa/extension-tao-itemqti-pic": "6.0.0",
     "oat-sa/extension-tao-test": "15.0.0",
     "oat-sa/extension-tao-testqti": "41.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0993dcf3c39e2a7d2a482e221f5e449d",
+    "content-hash": "7bdf2a8943cce6db62f0f859699f0538",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3477,16 +3477,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v27.1.0",
+            "version": "v27.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "0aabe8780ef333f0590a2733db50894d81a817a7"
+                "reference": "4d4491dd4042d45105ed4a6e6744c802ad10c5b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/0aabe8780ef333f0590a2733db50894d81a817a7",
-                "reference": "0aabe8780ef333f0590a2733db50894d81a817a7",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/4d4491dd4042d45105ed4a6e6744c802ad10c5b3",
+                "reference": "4d4491dd4042d45105ed4a6e6744c802ad10c5b3",
                 "shasum": ""
             },
             "require": {
@@ -3561,9 +3561,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v27.1.0"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v27.1.1"
             },
-            "time": "2021-02-26T09:54:12+00:00"
+            "time": "2021-03-02T12:40:13+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
Update "oat-sa/extension-tao-itemqti" to [27.1.1](https://github.com/oat-sa/extension-tao-itemqti/releases/tag/v27.1.1)