### PR TITLE
ci: release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+# This workflow will do a release after merge to develop branch
+
+name: generate composer files
+
+on:
+  pull_request:
+    branches:
+      - alpha
+    types: [opened, reopened]
+
+jobs:
+  auto-release:
+    name: automated Tao-community extension release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # Install PHP, composer v2
+      - name: Setup PHP,
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.2'
+          tools: composer:v2
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      # Generate composer.json file to fetch the latest releases of extensions
+      - name: Prepare composer file
+        if: always()
+        run: |
+          php -r '$composerArray = json_decode(file_get_contents("./composer.json"), true);
+          foreach ($composerArray["require"] as &$repository) {
+              $repository = "*";
+          }
+          file_put_contents("./composer-release.json", json_encode($composerArray, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));'
+
+      # Composer update
+      - name: Install dependencies
+        run: |
+          COMPOSER=composer-release.json composer update --no-dev --no-interaction --prefer-source
+
+      # Generate new composer.json file
+      - name: generate new composer.json
+        run: |
+          php -r '$composerArray = json_decode(file_get_contents("./composer.json"), true);
+          $composerLockArray = json_decode(file_get_contents("./composer-release.lock"), true);
+          foreach ($composerArray["require"] as $name => &$version) {
+              $version = getVersion($name, $composerLockArray);
+          }
+          file_put_contents("./composer.json", json_encode($composerArray, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+          function getVersion($name, $composerLockArray) {
+              foreach ($composerLockArray["packages"] as $package) {
+                  if ($package["name"] === $name) {
+                      break;
+                  }
+              }
+              return str_replace("v", "", $package["version"]);
+          }'
+
+      # Composer update
+      - name: Install dependencies
+        run: |
+          rm composer-release.json
+          rm composer-release.lock
+          COMPOSER_DISCARD_CHANGES=true composer update --no-dev --no-interaction --prefer-source
+
+      - name: Commit and push changes
+        uses: EndBug/add-and-commit@v7.0.0
+        with:
+          add: 'composer.*'
+          message: 'chore(release): update composer files'

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "stable",
     "require": {
         "oat-sa/generis": "14.2.1",
-        "oat-sa/tao-core": "48.0.5",
+        "oat-sa/tao-core": "48.0.4",
         "oat-sa/extension-tao-community": "10.0.0",
         "oat-sa/extension-tao-funcacl": "7.0.0",
         "oat-sa/extension-tao-dac-simple": "7.1.1",
@@ -34,7 +34,7 @@
         "oat-sa/extension-tao-group": "7.0.0",
         "oat-sa/extension-tao-item": "11.0.0",
         "oat-sa/extension-tao-itemqti-pci": "7.2.0",
-        "oat-sa/extension-tao-itemqti": "27.5.0",
+        "oat-sa/extension-tao-itemqti": "27.4.0",
         "oat-sa/extension-tao-itemqti-pic": "6.0.0",
         "oat-sa/extension-tao-test": "15.0.0",
         "oat-sa/extension-tao-testqti": "41.2.1",
@@ -55,7 +55,7 @@
         "oat-sa/extension-tao-clientdiag": "8.0.0",
         "oat-sa/extension-tao-eventlog": "3.0.0",
         "oat-sa/extension-tao-task-queue": "6.1.0",
-        "oat-sa/extension-tao-testqti-previewer": "3.0.2"
+        "oat-sa/extension-tao-testqti-previewer": "3.0.1"
     },
     "description": "TAO is an Open Source e-Testing platform that empowers you to build, deliver, and share innovative and engaging assessments online \u2013 in any language or subject matter."
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
   ],
   "repositories": [],
   "homepage": "http://www.taotesting.com",
+  "prefer-stable": true,
+  "minimum-stability": "stable",
   "require": {
     "oat-sa/generis": "14.2.1",
     "oat-sa/tao-core": "48.0.4",

--- a/composer.json
+++ b/composer.json
@@ -1,61 +1,61 @@
 {
-  "name": "oat-sa/tao-community",
-  "license": "GPL-2.0-only",
-  "config": {
-    "preferred-install": "dist"
-  },
-  "support": {
-    "issues": "http://forge.taotesting.com",
-    "forum": "http://forum.taotesting.com"
-  },
-  "authors": [
-    {
-      "homepage": "http://www.taotesting.com",
-      "name": "Open Assessment Technologies S.A."
-    }
-  ],
-  "keywords": [
-    "sprint 151.3",
-    "tao",
-    "oat",
-    "computer-based-assessment"
-  ],
-  "repositories": [],
-  "homepage": "http://www.taotesting.com",
-  "prefer-stable": true,
-  "minimum-stability": "stable",
-  "require": {
-    "oat-sa/generis": "14.2.1",
-    "oat-sa/tao-core": "48.0.4",
-    "oat-sa/extension-tao-community": "10.0.0",
-    "oat-sa/extension-tao-funcacl": "7.0.0",
-    "oat-sa/extension-tao-dac-simple": "7.1.1",
-    "oat-sa/extension-tao-testtaker": "8.0.0",
-    "oat-sa/extension-tao-group": "7.0.0",
-    "oat-sa/extension-tao-item": "11.0.0",
-    "oat-sa/extension-tao-itemqti-pci": "7.2.0",
-    "oat-sa/extension-tao-itemqti": "27.4.0",
-    "oat-sa/extension-tao-itemqti-pic": "6.0.0",
-    "oat-sa/extension-tao-test": "15.0.0",
-    "oat-sa/extension-tao-testqti": "41.2.1",
-    "oat-sa/extension-tao-outcome": "13.0.1",
-    "oat-sa/extension-tao-outcomeui": "10.4.0",
-    "oat-sa/extension-tao-outcomerds": "8.0.0",
-    "oat-sa/extension-tao-outcomekeyvalue": "6.0.0",
-    "oat-sa/extension-tao-outcomelti": "5.0.0",
-    "oat-sa/extension-tao-delivery": "15.0.1",
-    "oat-sa/extension-tao-delivery-rdf": "14.0.0",
-    "oat-sa/extension-tao-lti": "12.0.0",
-    "oat-sa/extension-tao-ltideliveryprovider": "12.0.0",
-    "oat-sa/extension-tao-revision": "10.0.0",
-    "oat-sa/extension-tao-mediamanager": "12.1.1",
-    "oat-sa/extension-pcisample": "3.0.0",
-    "oat-sa/extension-tao-backoffice": "6.0.0",
-    "oat-sa/extension-tao-proctoring": "20.0.1",
-    "oat-sa/extension-tao-clientdiag": "8.0.0",
-    "oat-sa/extension-tao-eventlog": "3.0.0",
-    "oat-sa/extension-tao-task-queue": "6.1.0",
-    "oat-sa/extension-tao-testqti-previewer": "3.0.1"
-  },
-  "description": "TAO is an Open Source e-Testing platform that empowers you to build, deliver, and share innovative and engaging assessments online – in any language or subject matter."
+    "name": "oat-sa/tao-community",
+    "license": "GPL-2.0-only",
+    "config": {
+        "preferred-install": "dist"
+    },
+    "support": {
+        "issues": "http://forge.taotesting.com",
+        "forum": "http://forum.taotesting.com"
+    },
+    "authors": [
+        {
+            "homepage": "http://www.taotesting.com",
+            "name": "Open Assessment Technologies S.A."
+        }
+    ],
+    "keywords": [
+        "sprint 151.3",
+        "tao",
+        "oat",
+        "computer-based-assessment"
+    ],
+    "repositories": [],
+    "homepage": "http://www.taotesting.com",
+    "prefer-stable": true,
+    "minimum-stability": "stable",
+    "require": {
+        "oat-sa/generis": "14.2.1",
+        "oat-sa/tao-core": "48.0.5",
+        "oat-sa/extension-tao-community": "10.0.0",
+        "oat-sa/extension-tao-funcacl": "7.0.0",
+        "oat-sa/extension-tao-dac-simple": "7.1.1",
+        "oat-sa/extension-tao-testtaker": "8.0.0",
+        "oat-sa/extension-tao-group": "7.0.0",
+        "oat-sa/extension-tao-item": "11.0.0",
+        "oat-sa/extension-tao-itemqti-pci": "7.2.0",
+        "oat-sa/extension-tao-itemqti": "27.5.0",
+        "oat-sa/extension-tao-itemqti-pic": "6.0.0",
+        "oat-sa/extension-tao-test": "15.0.0",
+        "oat-sa/extension-tao-testqti": "41.2.1",
+        "oat-sa/extension-tao-outcome": "13.0.1",
+        "oat-sa/extension-tao-outcomeui": "10.4.0",
+        "oat-sa/extension-tao-outcomerds": "8.0.0",
+        "oat-sa/extension-tao-outcomekeyvalue": "6.0.0",
+        "oat-sa/extension-tao-outcomelti": "5.0.0",
+        "oat-sa/extension-tao-delivery": "15.0.1",
+        "oat-sa/extension-tao-delivery-rdf": "14.0.0",
+        "oat-sa/extension-tao-lti": "12.0.0",
+        "oat-sa/extension-tao-ltideliveryprovider": "12.0.0",
+        "oat-sa/extension-tao-revision": "10.0.0",
+        "oat-sa/extension-tao-mediamanager": "12.1.1",
+        "oat-sa/extension-pcisample": "3.0.0",
+        "oat-sa/extension-tao-backoffice": "6.0.0",
+        "oat-sa/extension-tao-proctoring": "20.0.1",
+        "oat-sa/extension-tao-clientdiag": "8.0.0",
+        "oat-sa/extension-tao-eventlog": "3.0.0",
+        "oat-sa/extension-tao-task-queue": "6.1.0",
+        "oat-sa/extension-tao-testqti-previewer": "3.0.2"
+    },
+    "description": "TAO is an Open Source e-Testing platform that empowers you to build, deliver, and share innovative and engaging assessments online \u2013 in any language or subject matter."
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2acde4eaedffb70ba0b7fde280fe1716",
+    "content-hash": "06ebdef840d1300109b5d05ad56c2817",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3477,16 +3477,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v27.5.0",
+            "version": "v27.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "27b67a2c2311d44523473fe195dc8af2125050bb"
+                "reference": "cd14af480a9b5bb6486b7a2900e4a99fd40e3f2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/27b67a2c2311d44523473fe195dc8af2125050bb",
-                "reference": "27b67a2c2311d44523473fe195dc8af2125050bb",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/cd14af480a9b5bb6486b7a2900e4a99fd40e3f2f",
+                "reference": "cd14af480a9b5bb6486b7a2900e4a99fd40e3f2f",
                 "shasum": ""
             },
             "require": {
@@ -3561,9 +3561,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v27.5.0"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v27.4.0"
             },
-            "time": "2021-03-30T15:24:27+00:00"
+            "time": "2021-03-26T09:22:03+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",
@@ -4628,16 +4628,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
-            "version": "v3.0.2",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti-previewer.git",
-                "reference": "7155ff263c6a3faef511e7aef31951bcb236bdda"
+                "reference": "1517cb47d68ac1ef9bb853ea6ec997eebaca4169"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/7155ff263c6a3faef511e7aef31951bcb236bdda",
-                "reference": "7155ff263c6a3faef511e7aef31951bcb236bdda",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/1517cb47d68ac1ef9bb853ea6ec997eebaca4169",
+                "reference": "1517cb47d68ac1ef9bb853ea6ec997eebaca4169",
                 "shasum": ""
             },
             "require": {
@@ -4683,9 +4683,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.0.2"
+                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.0.1"
             },
-            "time": "2021-04-01T08:03:16+00:00"
+            "time": "2021-03-12T09:20:20+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testtaker",
@@ -5308,16 +5308,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v48.0.5",
+            "version": "v48.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "766534a2252befd5e8635eb5fd053d2e2cd865fa"
+                "reference": "60359e479b137572484e5943fea1effa6bd9edb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/766534a2252befd5e8635eb5fd053d2e2cd865fa",
-                "reference": "766534a2252befd5e8635eb5fd053d2e2cd865fa",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/60359e479b137572484e5943fea1effa6bd9edb6",
+                "reference": "60359e479b137572484e5943fea1effa6bd9edb6",
                 "shasum": ""
             },
             "require": {
@@ -5417,9 +5417,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v48.0.5"
+                "source": "https://github.com/oat-sa/tao-core/tree/v48.0.4"
             },
-            "time": "2021-04-01T09:03:09+00:00"
+            "time": "2021-03-31T18:13:52+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -8260,7 +8260,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
-    "prefer-stable": true,
+    "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06ebdef840d1300109b5d05ad56c2817",
+    "content-hash": "2acde4eaedffb70ba0b7fde280fe1716",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3477,16 +3477,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v27.4.0",
+            "version": "v27.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "cd14af480a9b5bb6486b7a2900e4a99fd40e3f2f"
+                "reference": "27b67a2c2311d44523473fe195dc8af2125050bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/cd14af480a9b5bb6486b7a2900e4a99fd40e3f2f",
-                "reference": "cd14af480a9b5bb6486b7a2900e4a99fd40e3f2f",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/27b67a2c2311d44523473fe195dc8af2125050bb",
+                "reference": "27b67a2c2311d44523473fe195dc8af2125050bb",
                 "shasum": ""
             },
             "require": {
@@ -3561,9 +3561,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v27.4.0"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v27.5.0"
             },
-            "time": "2021-03-26T09:22:03+00:00"
+            "time": "2021-03-30T15:24:27+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",
@@ -4628,16 +4628,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti-previewer.git",
-                "reference": "1517cb47d68ac1ef9bb853ea6ec997eebaca4169"
+                "reference": "7155ff263c6a3faef511e7aef31951bcb236bdda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/1517cb47d68ac1ef9bb853ea6ec997eebaca4169",
-                "reference": "1517cb47d68ac1ef9bb853ea6ec997eebaca4169",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/7155ff263c6a3faef511e7aef31951bcb236bdda",
+                "reference": "7155ff263c6a3faef511e7aef31951bcb236bdda",
                 "shasum": ""
             },
             "require": {
@@ -4683,9 +4683,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.0.1"
+                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.0.2"
             },
-            "time": "2021-03-12T09:20:20+00:00"
+            "time": "2021-04-01T08:03:16+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testtaker",
@@ -5308,16 +5308,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v48.0.4",
+            "version": "v48.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "60359e479b137572484e5943fea1effa6bd9edb6"
+                "reference": "766534a2252befd5e8635eb5fd053d2e2cd865fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/60359e479b137572484e5943fea1effa6bd9edb6",
-                "reference": "60359e479b137572484e5943fea1effa6bd9edb6",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/766534a2252befd5e8635eb5fd053d2e2cd865fa",
+                "reference": "766534a2252befd5e8635eb5fd053d2e2cd865fa",
                 "shasum": ""
             },
             "require": {
@@ -5417,9 +5417,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v48.0.4"
+                "source": "https://github.com/oat-sa/tao-core/tree/v48.0.5"
             },
-            "time": "2021-03-31T18:13:52+00:00"
+            "time": "2021-04-01T09:03:09+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -8260,7 +8260,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],


### PR DESCRIPTION
This action supposed to fix (`ghtoolkit release prepare` broken since version were removed from manifest files) and automate this procedure: https://github.com/oat-sa/github-tools/wiki/Sprint-release-procedure#31-prepare-the-release-of-tao-community

Action triggers when new PR into `alpha` branch opened/reopened 

Action generates new `composer.json` and `composer.lock` files according to the latest released versions of extensions.

NOTE: versions in `composer.json` in this PR file was not changed. Just changed formatting and added two directives:
```
    "prefer-stable": true,
    "minimum-stability": "stable",
```

The workflow is the following:
1. create new `composer-release.json` file with all dependencies version set to `'*'`
2. do `composer update` to generate `composer-release.lock` file where all the dependencies will have the latest released version (thanks to miminum stability set to `stable`)
3. get latest released versions from `composer-release.lock` and update versions in original `composer.json`
4. do `composer update` to update original `composer.lock` file
5. push new commit