### PR TITLE
Fix: TR-996 404 for images in the test runner (extension-tao-itemqti …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,6 @@
 {
   "name": "oat-sa/tao-community",
   "license": "GPL-2.0-only",
-  "require-dev": {
-  },
   "config": {
     "preferred-install": "dist"
   },
@@ -35,7 +33,7 @@
     "oat-sa/extension-tao-testtaker": "7.7.2",
     "oat-sa/extension-tao-group": "6.6.2",
     "oat-sa/extension-tao-item": "10.9.0",
-    "oat-sa/extension-tao-itemqti": "25.7.2.1",
+    "oat-sa/extension-tao-itemqti": "25.7.2.3",
     "oat-sa/extension-tao-itemqti-pci": "6.8.2",
     "oat-sa/extension-tao-itemqti-pic": "5.6.2",
     "oat-sa/extension-tao-test": "14.2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e05b3164f18e6b4f899b5af4d050923",
+    "content-hash": "04da6957c699f05bc5a68048d7d5438e",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -2304,16 +2304,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v25.7.2.1",
+            "version": "v25.7.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "df42054ef5ed4a105b1a900a22982eec16cd1b91"
+                "reference": "c6ee58ead25d8b351b6359142b80397e1ee42701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/df42054ef5ed4a105b1a900a22982eec16cd1b91",
-                "reference": "df42054ef5ed4a105b1a900a22982eec16cd1b91",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/c6ee58ead25d8b351b6359142b80397e1ee42701",
+                "reference": "c6ee58ead25d8b351b6359142b80397e1ee42701",
                 "shasum": ""
             },
             "require": {
@@ -2383,7 +2383,12 @@
                 "TAO",
                 "computer-based-assessment"
             ],
-            "time": "2021-03-24T15:55:25+00:00"
+            "support": {
+                "forum": "http://forum.taotesting.com",
+                "issues": "http://forge.taotesting.com",
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v25.7.2.3"
+            },
+            "time": "2021-04-13T14:01:47+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
Back-ported fix for TR-996

oat-sa/extension-tao-itemqti bumped to 25.7.2.3
Extension back-port PR: https://github.com/oat-sa/extension-tao-itemqti/pull/1694
Original fix: https://github.com/oat-sa/extension-tao-itemqti/pull/1528
