### PR TITLE
Hotfix/TR-1131/delay the size adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "oat-sa/extension-tao-testtaker": "7.7.2",
     "oat-sa/extension-tao-group": "6.6.2",
     "oat-sa/extension-tao-item": "10.9.0",
-    "oat-sa/extension-tao-itemqti": "25.7.2.4",
+    "oat-sa/extension-tao-itemqti": "25.7.2.5",
     "oat-sa/extension-tao-itemqti-pci": "6.8.2",
     "oat-sa/extension-tao-itemqti-pic": "5.6.2",
     "oat-sa/extension-tao-test": "14.2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d624f8a1023fc3ecd09d0079202d6c44",
+    "content-hash": "063e8bf45aee994ce5108d0eeaa2a4f3",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -2318,16 +2318,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v25.7.2.4",
+            "version": "v25.7.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "f5a1fe76cc6550b0756ce56f3ec4ce7f8f55eca6"
+                "reference": "cfa623c804eb1165a8af3aa76dda5e1b31cf2bc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/f5a1fe76cc6550b0756ce56f3ec4ce7f8f55eca6",
-                "reference": "f5a1fe76cc6550b0756ce56f3ec4ce7f8f55eca6",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/cfa623c804eb1165a8af3aa76dda5e1b31cf2bc4",
+                "reference": "cfa623c804eb1165a8af3aa76dda5e1b31cf2bc4",
                 "shasum": ""
             },
             "require": {
@@ -2397,7 +2397,7 @@
                 "TAO",
                 "computer-based-assessment"
             ],
-            "time": "2021-05-01T06:51:59+00:00"
+            "time": "2021-05-06T16:11:37+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1131

Delay a call to the sizeAdapter as some browsers are not emitting the load event on the LINK elements (Chrome).
The existing behaviour is kept, an additional delayed call is added to take care of this.