### PR TITLE
Upgrade extension-tao-clientdiag to 7.7.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "oat-sa/extension-pcisample": "2.10.2",
     "oat-sa/extension-tao-backoffice": "5.1.0",
     "oat-sa/extension-tao-proctoring": "19.18.5.2",
-    "oat-sa/extension-tao-clientdiag": "7.7.2",
+    "oat-sa/extension-tao-clientdiag": "7.7.2.1",
     "oat-sa/extension-tao-eventlog": "2.10.2",
     "oat-sa/extension-tao-task-queue": "5.4.1.1",
     "oat-sa/extension-tao-testqti-previewer": "2.17.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ccbe2810f096989491cce5578742673",
+    "content-hash": "bf67e20134dbc89cb940f57d28960fe3",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -1921,16 +1921,16 @@
         },
         {
             "name": "oat-sa/extension-tao-clientdiag",
-            "version": "v7.7.2",
+            "version": "v7.7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-clientdiag.git",
-                "reference": "047461525400e37cfe7ebabde83788c74f98ef34"
+                "reference": "5a7340d9e3567d9a02be1b09c0dc30fbe86a378f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-clientdiag/zipball/047461525400e37cfe7ebabde83788c74f98ef34",
-                "reference": "047461525400e37cfe7ebabde83788c74f98ef34",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-clientdiag/zipball/5a7340d9e3567d9a02be1b09c0dc30fbe86a378f",
+                "reference": "5a7340d9e3567d9a02be1b09c0dc30fbe86a378f",
                 "shasum": ""
             },
             "require": {
@@ -1961,7 +1961,7 @@
                 "TAO",
                 "computer-based-assessment"
             ],
-            "time": "2020-07-17T08:32:27+00:00"
+            "time": "2020-09-04T11:59:43+00:00"
         },
         {
             "name": "oat-sa/extension-tao-community",


### PR DESCRIPTION
This PR aims at adding the missing French translations for `extension-tao-clientdiag` into sprint 134. It seems we had the fix, but forgot to include it in `tao-enterprise-depp` (next release target) last year.