### PR TITLE
chore: bump taoTestTaker to 8.3.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "oat-sa/extension-tao-community": "10.1.1",
         "oat-sa/extension-tao-funcacl": "7.0.1",
         "oat-sa/extension-tao-dac-simple": "7.2.0.1",
-        "oat-sa/extension-tao-testtaker": "8.3.0.2",
+        "oat-sa/extension-tao-testtaker": "8.4.1.2",
         "oat-sa/extension-tao-group": "7.2.0.1",
         "oat-sa/extension-tao-item": "11.5.1.1",
         "oat-sa/extension-tao-itemqti-pci": "7.3.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "oat-sa/extension-tao-community": "10.1.1",
         "oat-sa/extension-tao-funcacl": "7.0.1",
         "oat-sa/extension-tao-dac-simple": "7.2.0.1",
-        "oat-sa/extension-tao-testtaker": "8.3.0.1",
+        "oat-sa/extension-tao-testtaker": "8.3.0.2",
         "oat-sa/extension-tao-group": "7.2.0.1",
         "oat-sa/extension-tao-item": "11.5.1.1",
         "oat-sa/extension-tao-itemqti-pci": "7.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6dd77f4de9e54ee94ad2380198f2675",
+    "content-hash": "eecd3ba47597cd9d8c6d1a4344af6f94",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4637,16 +4637,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testtaker",
-            "version": "v8.3.0.2",
+            "version": "v8.4.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testtaker.git",
-                "reference": "695b8e99bfa18c622544f38d2f82c6be6b43426c"
+                "reference": "65be47ef568a7664545c9dbc7f12d16fdecd4836"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testtaker/zipball/695b8e99bfa18c622544f38d2f82c6be6b43426c",
-                "reference": "695b8e99bfa18c622544f38d2f82c6be6b43426c",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testtaker/zipball/65be47ef568a7664545c9dbc7f12d16fdecd4836",
+                "reference": "65be47ef568a7664545c9dbc7f12d16fdecd4836",
                 "shasum": ""
             },
             "require": {
@@ -4712,9 +4712,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testtaker/tree/v8.3.0.2"
+                "source": "https://github.com/oat-sa/extension-tao-testtaker/tree/v8.4.1.2"
             },
-            "time": "2021-09-15T10:44:52+00:00"
+            "time": "2021-09-30T11:21:28+00:00"
         },
         {
             "name": "oat-sa/generis",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd1119b6e62905e476b3784415942f67",
+    "content-hash": "e6dd77f4de9e54ee94ad2380198f2675",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4637,16 +4637,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testtaker",
-            "version": "v8.3.0.1",
+            "version": "v8.3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testtaker.git",
-                "reference": "7ea7eb1d2c6328bb3096db0d107baaee4a2f3a70"
+                "reference": "695b8e99bfa18c622544f38d2f82c6be6b43426c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testtaker/zipball/7ea7eb1d2c6328bb3096db0d107baaee4a2f3a70",
-                "reference": "7ea7eb1d2c6328bb3096db0d107baaee4a2f3a70",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testtaker/zipball/695b8e99bfa18c622544f38d2f82c6be6b43426c",
+                "reference": "695b8e99bfa18c622544f38d2f82c6be6b43426c",
                 "shasum": ""
             },
             "require": {
@@ -4712,9 +4712,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testtaker/tree/v8.3.0.1"
+                "source": "https://github.com/oat-sa/extension-tao-testtaker/tree/v8.3.0.2"
             },
-            "time": "2021-07-21T15:31:20+00:00"
+            "time": "2021-09-15T10:44:52+00:00"
         },
         {
             "name": "oat-sa/generis",
@@ -8297,5 +8297,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Ticket [RO-576](https://oat-sa.atlassian.net/browse/RO-576)

Fixes issue where config file for test taker extension is not created on install