### PR TITLE
fix(dependencies): update itemqti to 28.19.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "oat-sa/extension-tao-group": "7.5.0",
         "oat-sa/extension-tao-item": "11.16.0",
         "oat-sa/extension-tao-itemqti-pci": "7.7.0",
-        "oat-sa/extension-tao-itemqti": "v28.19.5",
+        "oat-sa/extension-tao-itemqti": "28.19.6",
         "oat-sa/extension-tao-itemqti-pic": "6.1.0",
         "oat-sa/extension-tao-test": "15.7.0",
         "oat-sa/extension-tao-testqti": "41.15.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d9a873812d5a58fcab483cebcf9e576",
+    "content-hash": "35632ea52d3a6ce870fe88c398871ead",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3421,16 +3421,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v28.19.5",
+            "version": "v28.19.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "f835876f48c634fe6849e5df0d066c7601662a10"
+                "reference": "f1ae92c490385cff9fd3d84aa4a5f68b7134b69f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/f835876f48c634fe6849e5df0d066c7601662a10",
-                "reference": "f835876f48c634fe6849e5df0d066c7601662a10",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/f1ae92c490385cff9fd3d84aa4a5f68b7134b69f",
+                "reference": "f1ae92c490385cff9fd3d84aa4a5f68b7134b69f",
                 "shasum": ""
             },
             "require": {
@@ -3505,9 +3505,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v28.19.5"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v28.19.6"
             },
-            "time": "2021-10-07T16:35:51+00:00"
+            "time": "2021-10-18T07:00:21+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",
@@ -9058,5 +9058,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
**Related to:**  https://oat-sa.atlassian.net/browse/AUT-665

**Description:** Update `oat-sa/extension-tao-itemqti` to [28.19.6](https://github.com/oat-sa/extension-tao-itemqti/releases/tag/v28.19.6) as it [updates ](https://github.com/oat-sa/extension-tao-itemqti/pull/1924/files#diff-03c6d048c4955944172f34af2a152ae6cbd4ffc2ec11fcd4bc7cd44b194f249cR12)`tao-item-runner-qti-fe` to [0.24.1](https://github.com/oat-sa/tao-item-runner-qti-fe/releases/tag/v0.24.1)