### PR TITLE
[Backport] tr 2381/test runner connectivity fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   "prefer-stable": true,
   "require": {
         "oat-sa/generis": "15.2.0",
-        "oat-sa/tao-core": "48.31.1.1",
+        "oat-sa/tao-core": "48.31.1.2",
         "oat-sa/extension-tao-community": "10.1.1",
         "oat-sa/extension-tao-funcacl": "7.0.1",
         "oat-sa/extension-tao-dac-simple": "7.3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4ad98c230d6948b6c4f86ddcde8884d",
+    "content-hash": "353876bbb9c7fa5cd6746b9c3bc14dd5",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -5170,16 +5170,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v48.31.1.1",
+            "version": "v48.31.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "dfaef1d63f3b05cf68c6e360453a24fb8abcff1c"
+                "reference": "4b4448a4c999e4ccf11cb323ac02894e0fe8f935"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/dfaef1d63f3b05cf68c6e360453a24fb8abcff1c",
-                "reference": "dfaef1d63f3b05cf68c6e360453a24fb8abcff1c",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/4b4448a4c999e4ccf11cb323ac02894e0fe8f935",
+                "reference": "4b4448a4c999e4ccf11cb323ac02894e0fe8f935",
                 "shasum": ""
             },
             "require": {
@@ -5279,9 +5279,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v48.31.1.1"
+                "source": "https://github.com/oat-sa/tao-core/tree/v48.31.1.2"
             },
-            "time": "2021-10-08T10:16:10+00:00"
+            "time": "2021-10-28T12:49:30+00:00"
         },
         {
             "name": "ocramius/proxy-manager",


### PR DESCRIPTION
For https://oat-sa.atlassian.net/browse/TR-2381

Backports for `2021.10.3` of:

## tao [48.31.1.2](https://github.com/oat-sa/tao-core/releases/tag/v48.31.1.2)
  - TR-1911 fresh installation failure
  - TR-1460 https://github.com/oat-sa/tao-core/pull/3185

## taoProctoring [20.1.1.1](https://github.com/oat-sa/extension-tao-proctoring/releases/tag/v20.1.1.1)
  - TR-2217 https://github.com/oat-sa/extension-tao-proctoring/pull/905

## taoQtiTest [41.14.2](https://github.com/oat-sa/extension-tao-testqti/releases/tag/v41.14.2)
  - TR-1473 https://github.com/oat-sa/extension-tao-testqti/pull/2094
  - TR-1970 https://github.com/oat-sa/extension-tao-testqti/pull/2083

Please install and check it.

Can be checked as plain TAO, or if you like, using attached composer (modified from [last release of tao-enterprise-bosa](https://github.com/oat-sa/tao-enterprise-bosa/blob/release-0.156.3.1-alpha/composer.json)).
[composer-bosa.json.txt](https://github.com/oat-sa/tao-community/files/7435560/composer-bosa.json.txt)

Installing this (e.g. `composer install` & `taoDockerize install -e taoBosaSelor`) gives me a working platform with:
<img width="570" alt="Screenshot 2021-10-28 at 17 36 39" src="https://user-images.githubusercontent.com/43652944/139289550-16e04e99-cfbd-4208-93f3-e4b5c68a5a8d.png">

