### PR TITLE
Hotfix/TR 3646/calculator ar arb translation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "oat-sa/extension-tao-funcacl": "7.2.0",
         "oat-sa/extension-tao-dac-simple": "7.4.1",
         "oat-sa/extension-tao-itemqti": "28.39.5",
-        "oat-sa/extension-tao-testqti": "44.10.1",
+        "oat-sa/extension-tao-testqti": "44.10.2",
         "oat-sa/extension-tao-testtaker": "8.7.2",
         "oat-sa/extension-tao-group": "7.6.0",
         "oat-sa/extension-tao-item": "11.26.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf1e00b84faba633ef034424fd097e93",
+    "content-hash": "b279982f187e2f983131ac55991a4d6c",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4566,16 +4566,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti",
-            "version": "v44.10.1",
+            "version": "v44.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "a1b08fd9d1e2d23b6bbeb8f3cf66b6ff113c6e24"
+                "reference": "84ac0b52b7465903224c351932b86273a27ede9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/a1b08fd9d1e2d23b6bbeb8f3cf66b6ff113c6e24",
-                "reference": "a1b08fd9d1e2d23b6bbeb8f3cf66b6ff113c6e24",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/84ac0b52b7465903224c351932b86273a27ede9e",
+                "reference": "84ac0b52b7465903224c351932b86273a27ede9e",
                 "shasum": ""
             },
             "require": {
@@ -4658,9 +4658,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v44.10.1"
+                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v44.10.2"
             },
-            "time": "2022-03-04T16:34:39+00:00"
+            "time": "2022-03-11T15:16:39+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
@@ -9217,5 +9217,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -9217,5 +9217,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3646
See last 2 comments in the ticket.

In April 2022 release, `extension-tao-testqti` is missing the fix for this ticket.
So we need to update it to https://github.com/oat-sa/extension-tao-testqti/releases/tag/v44.10.2
Note that this release also includes https://oat-sa.atlassian.net/browse/TR-3354 , but it looks ok to include it.