### PR TITLE
chore: update with backport for tr-2754

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "prefer-stable": true,
   "require": {
         "oat-sa/generis": "15.5.2",
-        "oat-sa/tao-core": "48.45.9",
+        "oat-sa/tao-core": "48.45.10",
         "oat-sa/extension-tao-community": "10.1.2",
         "oat-sa/extension-tao-funcacl": "7.0.1",
         "oat-sa/extension-tao-dac-simple": "7.3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a09f92c8960b1a7c24cde6931be7ba7",
+    "content-hash": "ffdb8f50e043a0f44707256f6d3f4372",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -5254,16 +5254,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "48.45.9",
+            "version": "v48.45.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "e5ecbfef7730fd4052f42661724d72f34bcb5704"
+                "reference": "bb8c1f7fca99d7b44eef489fe4b825db2cf3b747"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/e5ecbfef7730fd4052f42661724d72f34bcb5704",
-                "reference": "e5ecbfef7730fd4052f42661724d72f34bcb5704",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/bb8c1f7fca99d7b44eef489fe4b825db2cf3b747",
+                "reference": "bb8c1f7fca99d7b44eef489fe4b825db2cf3b747",
                 "shasum": ""
             },
             "require": {
@@ -5365,9 +5365,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/48.45.9"
+                "source": "https://github.com/oat-sa/tao-core/tree/v48.45.10"
             },
-            "time": "2022-02-18T10:30:51+00:00"
+            "time": "2022-03-18T11:20:08+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -9077,5 +9077,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Backport of https://github.com/oat-sa/tao-core/pull/3368 for https://oat-sa.atlassian.net/browse/TR-3785, targeting November release.