### PR TITLE
[FIXED] github protocol

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "homepage": "http://www.taotesting.com",
   "require": {
     "oat-sa/generis": "13.14.1",
-    "oat-sa/tao-core": "46.14.8",
+    "oat-sa/tao-core": "46.14.9",
     "oat-sa/extension-tao-community": "9.2.0",
     "oat-sa/extension-tao-funcacl": "6.0.1",
     "oat-sa/extension-tao-dac-simple": "6.8.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2186d8d08a95be93b77c9b1caa1d357e",
+    "content-hash": "c48201b41ec698dc3f71915ab954c6d2",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4951,16 +4951,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v46.14.8",
+            "version": "46.14.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "db964bd07427ae36425020b238cab00a90e2320c"
+                "reference": "337ffd2eb045bf5c3137b0cc72f04e0383b53bc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/db964bd07427ae36425020b238cab00a90e2320c",
-                "reference": "db964bd07427ae36425020b238cab00a90e2320c",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/337ffd2eb045bf5c3137b0cc72f04e0383b53bc3",
+                "reference": "337ffd2eb045bf5c3137b0cc72f04e0383b53bc3",
                 "shasum": ""
             },
             "require": {
@@ -4998,17 +4998,17 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "oat\\tao\\controller\\": "controller",
-                    "oat\\tao\\model\\": "models/classes/",
-                    "oat\\tao\\helpers\\": "helpers",
-                    "oat\\tao\\test\\": "test",
-                    "oat\\tao\\scripts\\": "scripts",
-                    "oat\\tao\\install\\": "install"
-                },
                 "files": [
                     "includes/globalHelpers.php"
-                ]
+                ],
+                "psr-4": {
+                    "oat\\tao\\test\\": "test",
+                    "oat\\tao\\model\\": "models/classes/",
+                    "oat\\tao\\helpers\\": "helpers",
+                    "oat\\tao\\install\\": "install",
+                    "oat\\tao\\scripts\\": "scripts",
+                    "oat\\tao\\controller\\": "controller"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5058,9 +5058,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v46.14.8"
+                "source": "https://github.com/oat-sa/tao-core/tree/46.14.9"
             },
-            "time": "2021-04-13T13:49:30+00:00"
+            "time": "2022-03-22T09:43:46+00:00"
         },
         {
             "name": "ocramius/proxy-manager",


### PR DESCRIPTION
Change the GitHub protocol to fix issue: 

```
npm ERR! Error while executing:
npm ERR! /usr/local/bin/git ls-remote -h -t git://github.com/adobe-webplatform/eve.git
npm ERR! 
npm ERR! fatal: remote error: 
npm ERR!   The unauthenticated git protocol on port 9418 is no longer supported.
npm ERR! Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
npm ERR! 
npm ERR! exited with error code: 128

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/andremachado/.npm/_logs/2022-03-22T08_17_43_745Z-debug.log
```
found in: https://eu-west-1.console.aws.amazon.com/codesuite/codebuild/569653512379/projects/ltnec01dep-code-update/build/ltnec01dep-code-update%3A4ad9c635-f10a-4586-a035-cfe2a4912716/?region=eu-west-1
please check : https://oatsa.slack.com/archives/CHV6WAE90/p1641975451033400?thread_ts=1641975039.032500&cid=CHV6WAE90 for more details.