### PR TITLE
[2022.04] Fix/Use legacy container in migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,11 @@
     "platform": {
       "php": "7.2.5"
     },
-    "preferred-install": "dist"
+    "preferred-install": "dist",
+    "allow-plugins": {
+      "oat-sa/oatbox-extension-installer": true,
+      "oat-sa/composer-npm-bridge": true
+    }
   },
   "support": {
     "issues": "http://forge.taotesting.com",
@@ -55,7 +59,7 @@
         "oat-sa/extension-tao-backoffice": "6.10.0",
         "oat-sa/extension-tao-proctoring": "20.4.1",
         "oat-sa/extension-tao-clientdiag": "8.4.0",
-        "oat-sa/extension-tao-eventlog": "3.3.0",
+        "oat-sa/extension-tao-eventlog": "3.3.1",
         "oat-sa/extension-tao-task-queue": "6.6.1",
         "oat-sa/extension-tao-testqti-previewer": "3.5.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b279982f187e2f983131ac55991a4d6c",
+    "content-hash": "2c579a9d7cef6986be893d85ff77a79f",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3200,16 +3200,16 @@
         },
         {
             "name": "oat-sa/extension-tao-eventlog",
-            "version": "v3.3.0",
+            "version": "v3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-eventlog.git",
-                "reference": "6fbacc53e4d9da312c14a5cb1a288a3852f325bb"
+                "reference": "87ba36d27458e42fc266d06d7fcee573367afa9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-eventlog/zipball/6fbacc53e4d9da312c14a5cb1a288a3852f325bb",
-                "reference": "6fbacc53e4d9da312c14a5cb1a288a3852f325bb",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-eventlog/zipball/87ba36d27458e42fc266d06d7fcee573367afa9c",
+                "reference": "87ba36d27458e42fc266d06d7fcee573367afa9c",
                 "shasum": ""
             },
             "require": {
@@ -3251,9 +3251,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-tao-eventlog/issues",
-                "source": "https://github.com/oat-sa/extension-tao-eventlog/tree/v3.3.0"
+                "source": "https://github.com/oat-sa/extension-tao-eventlog/tree/v3.3.1"
             },
-            "time": "2021-12-20T09:59:23+00:00"
+            "time": "2022-03-24T12:45:38+00:00"
         },
         {
             "name": "oat-sa/extension-tao-funcacl",
@@ -9217,5 +9217,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
## Changes
* `oat-sa/extension-tao-eventlog` updated for `3.3.0` to `3.3.1`