### PR TITLE
Hotfix/AUT-1879/2022.03/disable token store for test preview

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "oat-sa/extension-tao-clientdiag": "8.4.0",
         "oat-sa/extension-tao-eventlog": "3.3.1",
         "oat-sa/extension-tao-task-queue": "6.6.1",
-        "oat-sa/extension-tao-testqti-previewer": "3.4.1"
+        "oat-sa/extension-tao-testqti-previewer": "3.4.2"
   },
   "description": "TAO is an Open Source e-Testing platform that empowers you to build, deliver, and share innovative and engaging assessments online – in any language or subject matter."
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd527aad34a80a34eeb700ac82f0b562",
+    "content-hash": "2ba8eb2b2bb0f9c0da5e85d550ca3909",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4656,16 +4656,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
-            "version": "v3.4.1",
+            "version": "v3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti-previewer.git",
-                "reference": "0c2ea51b7481e4a84b2b2a2e11ec80208919f268"
+                "reference": "7e552b04598403d4d329c2d6db708e0b52eb6800"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/0c2ea51b7481e4a84b2b2a2e11ec80208919f268",
-                "reference": "0c2ea51b7481e4a84b2b2a2e11ec80208919f268",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/7e552b04598403d4d329c2d6db708e0b52eb6800",
+                "reference": "7e552b04598403d4d329c2d6db708e0b52eb6800",
                 "shasum": ""
             },
             "require": {
@@ -4711,9 +4711,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.4.1"
+                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.4.2"
             },
-            "time": "2022-02-04T09:42:51+00:00"
+            "time": "2022-03-30T10:44:09+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testtaker",
@@ -9207,5 +9207,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1879

Backport of https://github.com/oat-sa/extension-tao-testqti-previewer/pull/161 into the release 2022.03