### PR TITLE
chore: include backported fix for mediamanager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "oat-sa/extension-tao-lti": "14.0.0",
         "oat-sa/extension-tao-ltideliveryprovider": "12.3.0",
         "oat-sa/extension-tao-revision": "10.3.0",
-        "oat-sa/extension-tao-mediamanager": "12.14.2",
+        "oat-sa/extension-tao-mediamanager": "12.14.2.1",
         "oat-sa/extension-pcisample": "3.1.1.3",
         "oat-sa/extension-tao-backoffice": "6.3.0",
         "oat-sa/extension-tao-proctoring": "20.1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5377af297dc5c06e3ab60910e5482280",
+    "content-hash": "7136285521c0d5bdcbf360d3c4b6feac",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3777,16 +3777,16 @@
         },
         {
             "name": "oat-sa/extension-tao-mediamanager",
-            "version": "v12.14.2",
+            "version": "v12.14.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-mediamanager.git",
-                "reference": "fbe8489bf3bae7a18d67aa19c0d5662f661dbf5c"
+                "reference": "ca5ba4781a990a33f4c6319161a57fbba1c25f33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-mediamanager/zipball/fbe8489bf3bae7a18d67aa19c0d5662f661dbf5c",
-                "reference": "fbe8489bf3bae7a18d67aa19c0d5662f661dbf5c",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-mediamanager/zipball/ca5ba4781a990a33f4c6319161a57fbba1c25f33",
+                "reference": "ca5ba4781a990a33f4c6319161a57fbba1c25f33",
                 "shasum": ""
             },
             "require": {
@@ -3826,9 +3826,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-mediamanager/tree/v12.14.2"
+                "source": "https://github.com/oat-sa/extension-tao-mediamanager/tree/v12.14.2.1"
             },
-            "time": "2022-02-03T14:39:12+00:00"
+            "time": "2022-03-31T08:13:53+00:00"
         },
         {
             "name": "oat-sa/extension-tao-outcome",
@@ -9077,5 +9077,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
include [oat-sa/extension-tao-mediamanager v12.14.2.1](https://github.com/oat-sa/extension-tao-mediamanager/releases/tag/v12.14.2.1)