### PR TITLE
Hotfix/AUT-1879/2022.11/disable token store for test preview

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "oat-sa/extension-tao-clientdiag": "8.3.0",
         "oat-sa/extension-tao-eventlog": "3.1.1",
         "oat-sa/extension-tao-task-queue": "6.5.3",
-        "oat-sa/extension-tao-testqti-previewer": "3.1.5"
+        "oat-sa/extension-tao-testqti-previewer": "3.1.6"
   },
   "description": "TAO is an Open Source e-Testing platform that empowers you to build, deliver, and share innovative and engaging assessments online – in any language or subject matter."
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7136285521c0d5bdcbf360d3c4b6feac",
+    "content-hash": "30371e8ddbab46ee629c04206817f079",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4569,16 +4569,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti-previewer.git",
-                "reference": "39923cbec42c94930cc1ea57ac9d681196d6ca94"
+                "reference": "273c2e1be6ca73bb2932ec10b184f33041a0cb7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/39923cbec42c94930cc1ea57ac9d681196d6ca94",
-                "reference": "39923cbec42c94930cc1ea57ac9d681196d6ca94",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/273c2e1be6ca73bb2932ec10b184f33041a0cb7b",
+                "reference": "273c2e1be6ca73bb2932ec10b184f33041a0cb7b",
                 "shasum": ""
             },
             "require": {
@@ -4624,9 +4624,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.1.5"
+                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.1.6"
             },
-            "time": "2022-02-18T09:16:07+00:00"
+            "time": "2022-04-01T09:48:56+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testtaker",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1879

Backport of https://github.com/oat-sa/extension-tao-testqti-previewer/pull/161 into the release 2022.11