### PR TITLE
March release backports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "oat-sa/extension-tao-testtaker": "8.9.0",
         "oat-sa/extension-tao-group": "7.6.0",
         "oat-sa/extension-tao-item": "11.28.0",
-        "oat-sa/extension-tao-itemqti-pci": "8.0.1",
+        "oat-sa/extension-tao-itemqti-pci": "8.0.2",
         "oat-sa/extension-tao-itemqti-pic": "6.3.0",
         "oat-sa/extension-tao-test": "15.13.0",
         "oat-sa/extension-tao-outcome": "13.1.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "prefer-stable": true,
   "require": {
         "oat-sa/generis": "15.19.2",
-        "oat-sa/tao-core": "50.10.1",
+        "oat-sa/tao-core": "50.10.2",
         "oat-sa/extension-tao-community": "10.3.0",
         "oat-sa/extension-tao-funcacl": "7.2.0",
         "oat-sa/extension-tao-dac-simple": "7.4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "433ed4d7a9f6af87733cb1d82b42a83d",
+    "content-hash": "9020a08721c31c4fe1cb970412103ce3",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -5562,16 +5562,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v50.10.1",
+            "version": "v50.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "12831eaea9380cc2bf192d646dd11b48e40cc4e9"
+                "reference": "9727e1fda1ad31943e8d9886935156762e7dc220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/12831eaea9380cc2bf192d646dd11b48e40cc4e9",
-                "reference": "12831eaea9380cc2bf192d646dd11b48e40cc4e9",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/9727e1fda1ad31943e8d9886935156762e7dc220",
+                "reference": "9727e1fda1ad31943e8d9886935156762e7dc220",
                 "shasum": ""
             },
             "require": {
@@ -5673,9 +5673,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v50.10.1"
+                "source": "https://github.com/oat-sa/tao-core/tree/v50.10.2"
             },
-            "time": "2022-04-12T14:46:54+00:00"
+            "time": "2022-04-13T15:12:39+00:00"
         },
         {
             "name": "ocramius/proxy-manager",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a99e8c914d9f78c7d243c58907af596",
+    "content-hash": "433ed4d7a9f6af87733cb1d82b42a83d",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3770,16 +3770,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",
-            "version": "v8.0.1",
+            "version": "v8.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti-pci.git",
-                "reference": "31b841802823b7e4f9ed1c7045f57cb3dd4cc166"
+                "reference": "92f8a51469aaac8d145789b8fe1f40c420514c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti-pci/zipball/31b841802823b7e4f9ed1c7045f57cb3dd4cc166",
-                "reference": "31b841802823b7e4f9ed1c7045f57cb3dd4cc166",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti-pci/zipball/92f8a51469aaac8d145789b8fe1f40c420514c9e",
+                "reference": "92f8a51469aaac8d145789b8fe1f40c420514c9e",
                 "shasum": ""
             },
             "require": {
@@ -3813,9 +3813,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-tao-itemqti-pci/issues",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti-pci/tree/v8.0.1"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti-pci/tree/v8.0.2"
             },
-            "time": "2022-03-28T10:22:04+00:00"
+            "time": "2022-04-14T15:03:13+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pic",
@@ -9385,5 +9385,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Updates contain the latest hotfixes, which were applied to March and April releases.

Backports no needed, as path versions were introduced since code freeze.

### Updated extensions:

**tao-core**: from 50.10.1 to 50.10.2
- Fix [REL-665](https://oat-sa.atlassian.net/browse/REL-665) : Checking empty value of label to avoid fatal errors https://github.com/oat-sa/tao-core/pull/3484

**qtiItemPci**: from 8.0.1 to 8.0.2
- Fix : chore: add missing bundle configuration https://github.com/oat-sa/extension-tao-itemqti-pci/pull/295