### PR TITLE
[Backport] included the option all on submittedVersion parameter #420

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "oat-sa/extension-tao-test": "14.6.2",
     "oat-sa/extension-tao-testqti": "40.3.13",
     "oat-sa/extension-tao-outcome": "12.3.3.1",
-    "oat-sa/extension-tao-outcomeui": "9.5.0.2",
+    "oat-sa/extension-tao-outcomeui": "9.5.0.4",
     "oat-sa/extension-tao-outcomerds": "7.3.2",
     "oat-sa/extension-tao-outcomekeyvalue": "5.7.1",
     "oat-sa/extension-tao-outcomelti": "4.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84db32406bb8113e8c10c67ccadb2e0c",
+    "content-hash": "ef01e5fbe3e0698235782b0d1eaca095",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3876,16 +3876,16 @@
         },
         {
             "name": "oat-sa/extension-tao-outcomeui",
-            "version": "v9.5.0.2",
+            "version": "9.5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-outcomeui.git",
-                "reference": "7b317f6a35b661ced85dfb486ce93f118a88e771"
+                "reference": "4a44d8cfee3b78c68f6809762b7268fc81fffb0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-outcomeui/zipball/7b317f6a35b661ced85dfb486ce93f118a88e771",
-                "reference": "7b317f6a35b661ced85dfb486ce93f118a88e771",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-outcomeui/zipball/4a44d8cfee3b78c68f6809762b7268fc81fffb0e",
+                "reference": "4a44d8cfee3b78c68f6809762b7268fc81fffb0e",
                 "shasum": ""
             },
             "require": {
@@ -3949,9 +3949,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-outcomeui/tree/v9.5.0.2"
+                "source": "https://github.com/oat-sa/extension-tao-outcomeui/tree/9.5.0.4"
             },
-            "time": "2022-03-22T13:51:18+00:00"
+            "time": "2022-04-21T09:45:57+00:00"
         },
         {
             "name": "oat-sa/extension-tao-proctoring",
@@ -7954,5 +7954,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Updated TAO community to include: 

Included the option all on submittedVersion parameter to be able to export all submitted versions at once.

## how to test
1. run the command:
```shell script
php index.php 'oat\taoOutcomeUi\scripts\task\ExportDeliveryResults' 'https://nmpp.nsa.etestavimas.lt#Delivery_2022spring_N2G81LTSL_1645454301' --columns=all --submittedVersion=all
```
2. check the output on `/path/to/tao/data/taskQueueStorage`