### PR TITLE
feat: Backport fix for item metadata importing to July 2022 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "oat-sa/extension-tao-community": "10.3.0",
     "oat-sa/extension-tao-funcacl": "7.2.0",
     "oat-sa/extension-tao-dac-simple": "7.7.0",
-    "oat-sa/extension-tao-itemqti": "29.3.1",
+    "oat-sa/extension-tao-itemqti": "29.3.2",
     "oat-sa/extension-tao-testqti": "44.18.0",
     "oat-sa/extension-tao-testtaker": "8.9.0",
     "oat-sa/extension-tao-group": "7.6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0a362307c48ae877aaaedf99fb30997",
+    "content-hash": "620ed4e161cdd28820340965e8216928",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3681,16 +3681,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.3.1",
+            "version": "v29.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "d0bfe402811a1f8cecbe95d8905e49885a654ca3"
+                "reference": "570cd56600b996cd3a9f12e97cefca02e3e43bfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/d0bfe402811a1f8cecbe95d8905e49885a654ca3",
-                "reference": "d0bfe402811a1f8cecbe95d8905e49885a654ca3",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/570cd56600b996cd3a9f12e97cefca02e3e43bfd",
+                "reference": "570cd56600b996cd3a9f12e97cefca02e3e43bfd",
                 "shasum": ""
             },
             "require": {
@@ -3766,9 +3766,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.3.1"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.3.2"
             },
-            "time": "2022-05-30T10:48:07+00:00"
+            "time": "2022-06-23T08:40:08+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
**Associated Jira issue:** [ADF-1073](https://oat-sa.atlassian.net/browse/ADF-1073)

- https://github.com/oat-sa/extension-tao-itemqti/compare/v29.3.1...v29.3.2

---

- [x] Test locally the update from the July release to this branch
- [x] Test the update works in the July integration environment

---

```
root@d27cba9fa7e4:/var/www/html# php tao/scripts/taoUpdate.php 
Xdebug: [Step Debug] Could not connect to debugging client. Tried: 192.168.1.156:9003 (through xdebug.client_host/xdebug.client_port) :-(
Running extension update
  generis already up to date
  tao already up to date
  taoResultServer already up to date
  taoOutcomeRds already up to date
  taoDelivery already up to date
  taoBackOffice already up to date
  taoTestTaker already up to date
  taoGroups already up to date
  taoItems already up to date
  taoTests already up to date
  taoQtiItem requires update from 29.3.1.0 to 29.3.2.0
    Successfully updated taoQtiItem to 29.3.2.0
  taoQtiTest already up to date
  taoDeliveryRdf already up to date
  taoOutcomeUi already up to date
  taoQtiTestPreviewer already up to date
  qtiItemPci already up to date
  funcAcl already up to date
  taoCe already up to date
  
 [OK] Already at the latest version ("oat\qtiItemPci\migrations\Version202204270746371465_qtiItemPci")                  


  Successfully updated 49 client translation bundles
  Post update actions:
    No actions to be executed
  Update ID : 62b42b71e3b10
  Update completed
  Dependency Injection Container rebuilt
  FeatureFlag cache cleared
root@d27cba9fa7e4:/var/www/html# 
```