### PR TITLE
Hotfix/tr 4339/custom theme in previewer from ClientConfig [August]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,10 @@
         "oat-sa/extension-tao-testqti": "44.19.3",
         "oat-sa/extension-tao-testtaker": "8.9.0",
         "oat-sa/extension-tao-group": "7.6.1",
-        "oat-sa/extension-tao-item": "11.30.0",
+        "oat-sa/extension-tao-item": "11.31.0",
         "oat-sa/extension-tao-itemqti-pci": "8.1.0",
         "oat-sa/extension-tao-itemqti-pic": "6.4.0",
-        "oat-sa/extension-tao-test": "15.13.0",
+        "oat-sa/extension-tao-test": "15.14.0",
         "oat-sa/extension-tao-outcome": "13.2.0",
         "oat-sa/extension-tao-outcomeui": "11.1.2",
         "oat-sa/extension-tao-outcomerds": "8.2.0",
@@ -61,7 +61,7 @@
         "oat-sa/extension-tao-clientdiag": "8.4.0",
         "oat-sa/extension-tao-eventlog": "3.3.1",
         "oat-sa/extension-tao-task-queue": "6.6.1",
-        "oat-sa/extension-tao-testqti-previewer": "3.5.2"
+        "oat-sa/extension-tao-testqti-previewer": "3.6.0"
   },
   "description": "TAO is an Open Source e-Testing platform that empowers you to build, deliver, and share innovative and engaging assessments online – in any language or subject matter."
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef4af0dc31fb4a5871ce97d930b582b1",
+    "content-hash": "56edcf752c5aecb2509560f5643be59f",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3675,16 +3675,16 @@
         },
         {
             "name": "oat-sa/extension-tao-item",
-            "version": "v11.30.0",
+            "version": "v11.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-item.git",
-                "reference": "a69416e4015e6e8df7b33e64eaa2949ed8edbcfe"
+                "reference": "0582b56b9d8f24228df022af77b5aa2087ee7b1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-item/zipball/a69416e4015e6e8df7b33e64eaa2949ed8edbcfe",
-                "reference": "a69416e4015e6e8df7b33e64eaa2949ed8edbcfe",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-item/zipball/0582b56b9d8f24228df022af77b5aa2087ee7b1e",
+                "reference": "0582b56b9d8f24228df022af77b5aa2087ee7b1e",
                 "shasum": ""
             },
             "require": {
@@ -3759,9 +3759,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-item/tree/v11.30.0"
+                "source": "https://github.com/oat-sa/extension-tao-item/tree/v11.31.0"
             },
-            "time": "2022-05-23T07:52:16+00:00"
+            "time": "2022-07-07T14:50:51+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
@@ -4731,16 +4731,16 @@
         },
         {
             "name": "oat-sa/extension-tao-test",
-            "version": "v15.13.0",
+            "version": "v15.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-test.git",
-                "reference": "38168f7a36467ed369d9eea7c8cf930bd1c99184"
+                "reference": "bf674100144b262504949c5548ef92bd25b989db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-test/zipball/38168f7a36467ed369d9eea7c8cf930bd1c99184",
-                "reference": "38168f7a36467ed369d9eea7c8cf930bd1c99184",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-test/zipball/bf674100144b262504949c5548ef92bd25b989db",
+                "reference": "bf674100144b262504949c5548ef92bd25b989db",
                 "shasum": ""
             },
             "require": {
@@ -4815,9 +4815,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org/",
                 "issues": "https://github.com/oat-sa/extension-tao-test/issues",
-                "source": "https://github.com/oat-sa/extension-tao-test/tree/v15.13.0"
+                "source": "https://github.com/oat-sa/extension-tao-test/tree/v15.14.0"
             },
-            "time": "2022-03-02T15:29:28+00:00"
+            "time": "2022-07-07T14:50:58+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti",
@@ -4919,16 +4919,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
-            "version": "v3.5.2",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti-previewer.git",
-                "reference": "192986ee9cad1167e69fd1868860afab79b71ab0"
+                "reference": "aedf4b3d131fe50b4c295fc1053accf3ecf01855"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/192986ee9cad1167e69fd1868860afab79b71ab0",
-                "reference": "192986ee9cad1167e69fd1868860afab79b71ab0",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/aedf4b3d131fe50b4c295fc1053accf3ecf01855",
+                "reference": "aedf4b3d131fe50b4c295fc1053accf3ecf01855",
                 "shasum": ""
             },
             "require": {
@@ -4974,9 +4974,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.5.2"
+                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.6.0"
             },
-            "time": "2022-04-25T09:42:13+00:00"
+            "time": "2022-07-07T14:52:58+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testtaker",
@@ -9472,5 +9472,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-4339

It's merged into September, should be backported to May.

Include
https://github.com/oat-sa/extension-tao-test/pull/425
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/170
https://github.com/oat-sa/extension-tao-item/pull/583

in the August release https://github.com/oat-sa/tao-community/blob/release-2022-08-lts/composer.json

TAE in ticket comments