### PR TITLE
chore: Update taoProctoring to use backported fix for TR-3081

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "oat-sa/extension-tao-mediamanager": "12.29.0",
         "oat-sa/extension-pcisample": "3.6.1",
         "oat-sa/extension-tao-backoffice": "6.11.0",
-        "oat-sa/extension-tao-proctoring": "20.5.0",
+        "oat-sa/extension-tao-proctoring": "v20.5.0.1",
         "oat-sa/extension-tao-clientdiag": "8.4.0",
         "oat-sa/extension-tao-eventlog": "3.3.1",
         "oat-sa/extension-tao-task-queue": "6.6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67accfb5055c85f759f7fbd0373d2f2f",
+    "content-hash": "ede16dce252d5f9371783ccc2ce806e6",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4563,16 +4563,16 @@
         },
         {
             "name": "oat-sa/extension-tao-proctoring",
-            "version": "v20.5.0",
+            "version": "v20.5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-proctoring.git",
-                "reference": "048ed2cb5c6bd00de5aedf71a0e0ddfb09faf9ac"
+                "reference": "9941e5bcb0644943271dcb765c7700d9ff421461"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-proctoring/zipball/048ed2cb5c6bd00de5aedf71a0e0ddfb09faf9ac",
-                "reference": "048ed2cb5c6bd00de5aedf71a0e0ddfb09faf9ac",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-proctoring/zipball/9941e5bcb0644943271dcb765c7700d9ff421461",
+                "reference": "9941e5bcb0644943271dcb765c7700d9ff421461",
                 "shasum": ""
             },
             "require": {
@@ -4615,9 +4615,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-tao-proctoring/issues",
-                "source": "https://github.com/oat-sa/extension-tao-proctoring/tree/v20.5.0"
+                "source": "https://github.com/oat-sa/extension-tao-proctoring/tree/v20.5.0.1"
             },
-            "time": "2022-03-17T10:43:47+00:00"
+            "time": "2022-08-12T10:11:43+00:00"
         },
         {
             "name": "oat-sa/extension-tao-revision",


### PR DESCRIPTION
**Associated Jira issue:** [TR-4566](https://oat-sa.atlassian.net/browse/TR-4566)

- Changelog: https://github.com/oat-sa/extension-tao-proctoring/compare/v20.5.0...v20.5.0.1
- Changes are cherry-picked from this PR: https://github.com/oat-sa/extension-tao-proctoring/pull/932
- Former issue: [TR-3081](https://oat-sa.atlassian.net/browse/TR-3081)

<details>
  <summary>Output for taoUpdate:</summary>

```
root@a8d1c19413a5:/var/www/html# php tao/scripts/taoUpdate.php 
Running extension update
  generis already up to date
  tao already up to date
  taoResultServer already up to date
  taoOutcomeRds already up to date
  taoDelivery already up to date
  taoBackOffice already up to date
  taoTestTaker already up to date
  taoGroups already up to date
  taoItems already up to date
  taoTests already up to date
  taoQtiItem already up to date
  taoQtiTest already up to date
  taoDeliveryRdf already up to date
  taoOutcomeUi already up to date
  taoQtiTestPreviewer already up to date
  qtiItemPci already up to date
  funcAcl already up to date
  taoCe already up to date
  taoDacSimple already up to date
  taoLti already up to date
  ltiDeliveryProvider already up to date
  taoEventLog already up to date
  taoLtiBasicOutcome already up to date
  pciSamples already up to date
  taoMediaManager already up to date
  taoTaskQueue already up to date
  qtiItemPic already up to date
  taoAltResultStorage already up to date
  taoClientDiagnostic already up to date
  taoRevision already up to date
  taoProctoring requires update from 20.5.0.0 to 20.5.0.1
    Successfully updated taoProctoring to 20.5.0.1
  
 [OK] Already at the latest version ("oat\taoProctoring\migrations\Version202203141404254101_taoProctoring")            


  Successfully updated 49 client translation bundles
  Post update actions:
    No actions to be executed
  Update ID : 62f62964883e4
  Update completed
  Dependency Injection Container rebuilt
  FeatureFlag cache cleared
root@a8d1c19413a5:/var/www/html# 
```
</details>