### PR TITLE
Fix/AUT-2591/bundle issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "oat-sa/extension-tao-mediamanager": "12.29.0",
         "oat-sa/extension-pcisample": "3.6.1",
         "oat-sa/extension-tao-backoffice": "6.11.0",
-        "oat-sa/extension-tao-proctoring": "v20.5.0.1",
+        "oat-sa/extension-tao-proctoring": "20.5.0.1",
         "oat-sa/extension-tao-clientdiag": "8.4.0",
         "oat-sa/extension-tao-eventlog": "3.3.1",
         "oat-sa/extension-tao-task-queue": "6.6.1",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "oat-sa/extension-tao-community": "10.3.0",
         "oat-sa/extension-tao-funcacl": "7.2.0",
         "oat-sa/extension-tao-dac-simple": "7.7.0",
-        "oat-sa/extension-tao-itemqti": "29.6.5",
+        "oat-sa/extension-tao-itemqti": "29.6.6",
         "oat-sa/extension-tao-testqti": "44.19.4",
         "oat-sa/extension-tao-testtaker": "8.9.0",
         "oat-sa/extension-tao-group": "7.6.1",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "oat-sa/extension-tao-mediamanager": "12.29.0",
         "oat-sa/extension-pcisample": "3.6.1",
         "oat-sa/extension-tao-backoffice": "6.11.0",
-        "oat-sa/extension-tao-proctoring": "20.5.0",
+        "oat-sa/extension-tao-proctoring": "v20.5.0.1",
         "oat-sa/extension-tao-clientdiag": "8.4.0",
         "oat-sa/extension-tao-eventlog": "3.3.1",
         "oat-sa/extension-tao-task-queue": "6.6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85b5ff99bb3d72936dc290ff7e13c8cb",
+    "content-hash": "e3d927dde82cc0ea8492ace0a39b1d83",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3765,16 +3765,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.6.5",
+            "version": "v29.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "83b95feb4ba3fcc93156c91fea3f5dc8a703cc40"
+                "reference": "4deac67bc0fb61b9a26380f45db4fcf33cb35d01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/83b95feb4ba3fcc93156c91fea3f5dc8a703cc40",
-                "reference": "83b95feb4ba3fcc93156c91fea3f5dc8a703cc40",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/4deac67bc0fb61b9a26380f45db4fcf33cb35d01",
+                "reference": "4deac67bc0fb61b9a26380f45db4fcf33cb35d01",
                 "shasum": ""
             },
             "require": {
@@ -3854,9 +3854,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.6.5"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.6.6"
             },
-            "time": "2022-07-22T13:53:36+00:00"
+            "time": "2022-08-16T12:45:21+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ede16dce252d5f9371783ccc2ce806e6",
+    "content-hash": "85b5ff99bb3d72936dc290ff7e13c8cb",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4567,12 +4567,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-proctoring.git",
-                "reference": "9941e5bcb0644943271dcb765c7700d9ff421461"
+                "reference": "575cab65b48781a3b81bfd7901bda0b5b17c3f42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-proctoring/zipball/9941e5bcb0644943271dcb765c7700d9ff421461",
-                "reference": "9941e5bcb0644943271dcb765c7700d9ff421461",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-proctoring/zipball/575cab65b48781a3b81bfd7901bda0b5b17c3f42",
+                "reference": "575cab65b48781a3b81bfd7901bda0b5b17c3f42",
                 "shasum": ""
             },
             "require": {
@@ -4617,7 +4617,7 @@
                 "issues": "https://github.com/oat-sa/extension-tao-proctoring/issues",
                 "source": "https://github.com/oat-sa/extension-tao-proctoring/tree/v20.5.0.1"
             },
-            "time": "2022-08-12T10:11:43+00:00"
+            "time": "2022-08-12T12:06:39+00:00"
         },
         {
             "name": "oat-sa/extension-tao-revision",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67accfb5055c85f759f7fbd0373d2f2f",
+    "content-hash": "ede16dce252d5f9371783ccc2ce806e6",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4563,16 +4563,16 @@
         },
         {
             "name": "oat-sa/extension-tao-proctoring",
-            "version": "v20.5.0",
+            "version": "v20.5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-proctoring.git",
-                "reference": "048ed2cb5c6bd00de5aedf71a0e0ddfb09faf9ac"
+                "reference": "9941e5bcb0644943271dcb765c7700d9ff421461"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-proctoring/zipball/048ed2cb5c6bd00de5aedf71a0e0ddfb09faf9ac",
-                "reference": "048ed2cb5c6bd00de5aedf71a0e0ddfb09faf9ac",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-proctoring/zipball/9941e5bcb0644943271dcb765c7700d9ff421461",
+                "reference": "9941e5bcb0644943271dcb765c7700d9ff421461",
                 "shasum": ""
             },
             "require": {
@@ -4615,9 +4615,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-tao-proctoring/issues",
-                "source": "https://github.com/oat-sa/extension-tao-proctoring/tree/v20.5.0"
+                "source": "https://github.com/oat-sa/extension-tao-proctoring/tree/v20.5.0.1"
             },
-            "time": "2022-03-17T10:43:47+00:00"
+            "time": "2022-08-12T10:11:43+00:00"
         },
         {
             "name": "oat-sa/extension-tao-revision",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2591

The bundles generated for the release of [tao-item-qti v29.6.5](https://github.com/oat-sa/extension-tao-itemqti/releases/tag/v29.6.5) contain issues. Most probably they were generated with an outdated version of the TAO bundler.
