### PR TITLE
hotfix: oat-sa/extension-tao-itemqti to 29.11.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "oat-sa/extension-tao-community": "10.3.0",
         "oat-sa/extension-tao-funcacl": "7.2.1",
         "oat-sa/extension-tao-dac-simple": "7.7.1",
-        "oat-sa/extension-tao-itemqti": "29.11.3",
+        "oat-sa/extension-tao-itemqti": "29.11.4",
         "oat-sa/extension-tao-testqti": "44.21.1",
         "oat-sa/extension-tao-testtaker": "8.9.1",
         "oat-sa/extension-tao-group": "7.6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85d915aa9914d1826256a0e65ad0ed6b",
+    "content-hash": "5dfe53e8863d6ee7b86fdc7ab6140264",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4026,16 +4026,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.11.3",
+            "version": "v29.11.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "a8b0a1aa6c93404d03469d564d53cfb50090e56e"
+                "reference": "6a043c38bb444087edd5d1aace059dd3717a9e12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/a8b0a1aa6c93404d03469d564d53cfb50090e56e",
-                "reference": "a8b0a1aa6c93404d03469d564d53cfb50090e56e",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/6a043c38bb444087edd5d1aace059dd3717a9e12",
+                "reference": "6a043c38bb444087edd5d1aace059dd3717a9e12",
                 "shasum": ""
             },
             "require": {
@@ -4115,9 +4115,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.11.3"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.11.4"
             },
-            "time": "2022-08-22T16:52:04+00:00"
+            "time": "2022-10-10T13:28:01+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2713

Update oat-sa/extension-tao-itemqti to [v29.11.4](https://github.com/oat-sa/extension-tao-itemqti/releases/tag/v29.11.4)

Depends on:

- [x] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/322
- [x] https://github.com/oat-sa/extension-tao-itemqti/pull/2243

Backport of https://github.com/oat-sa/tao-item-runner-qti-fe/pull/319 to [September Release](https://github.com/oat-sa/tao-community/blob/2022.09.3/composer.json#L39) to [taoQtiItem v29.11.3](https://github.com/oat-sa/extension-tao-itemqti/blob/v29.11.3/views/package.json#L12)