### PR TITLE
Release 2022.10.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "oat-sa/extension-tao-community": "10.3.0",
         "oat-sa/extension-tao-funcacl": "7.2.1",
         "oat-sa/extension-tao-dac-simple": "7.7.2",
-        "oat-sa/extension-tao-itemqti": "29.12.4.1",
+        "oat-sa/extension-tao-itemqti": "29.12.4.2",
         "oat-sa/extension-tao-testqti": "44.21.1",
         "oat-sa/extension-tao-testtaker": "8.9.2",
         "oat-sa/extension-tao-group": "7.6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "395c2c48c58332ee252d9d4f324018ae",
+    "content-hash": "fe938dfa1952e8d3f48a443c818a8d2d",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4026,16 +4026,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.12.4.1",
+            "version": "v29.12.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "7a1dbd29b6f610017e17cff42a5a9bd81c435134"
+                "reference": "0a20b185776a01a5b2836a8b08f26840b31eff9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/7a1dbd29b6f610017e17cff42a5a9bd81c435134",
-                "reference": "7a1dbd29b6f610017e17cff42a5a9bd81c435134",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/0a20b185776a01a5b2836a8b08f26840b31eff9a",
+                "reference": "0a20b185776a01a5b2836a8b08f26840b31eff9a",
                 "shasum": ""
             },
             "require": {
@@ -4115,9 +4115,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.12.4.1"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.12.4.2"
             },
-            "time": "2022-10-07T14:33:25+00:00"
+            "time": "2022-10-10T14:48:01+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",
@@ -9555,5 +9555,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2713

Update oat-sa/extension-tao-itemqti to [29.12.4.2](https://github.com/oat-sa/extension-tao-itemqti/releases/tag/v29.12.4.2)

Depends on:

- [x] https://github.com/oat-sa/tao-item-runner-qti-fe/pull/323
- [x] https://github.com/oat-sa/extension-tao-itemqti/pull/2244 

Backport of https://github.com/oat-sa/tao-item-runner-qti-fe/pull/319 to [October Release](https://github.com/oat-sa/tao-community/blob/2022.10.2/composer.json#L39) in [taoQtiItem v29.12.4.1](https://github.com/oat-sa/extension-tao-itemqti/blob/v29.12.4.1/views/package.json#L12)