### PR TITLE
Fix/TR-4575/Revert a fix breaking compliance with the IMS standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "oat-sa/extension-tao-testtaker": "8.9.2",
         "oat-sa/extension-tao-group": "7.6.2",
         "oat-sa/extension-tao-item": "11.31.3",
-        "oat-sa/extension-tao-itemqti-pci": "8.3.0",
+        "oat-sa/extension-tao-itemqti-pci": "8.3.1",
         "oat-sa/extension-tao-itemqti-pic": "6.4.0",
         "oat-sa/extension-tao-test": "15.15.0",
         "oat-sa/extension-tao-outcome": "13.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "092988e6af369913ea319686f2c012f9",
+    "content-hash": "202a13a80cb0ae554cf91d56936ad4d2",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4121,16 +4121,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",
-            "version": "v8.3.0",
+            "version": "v8.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti-pci.git",
-                "reference": "077e39864918aa8e50bc98e1017943a7f345d820"
+                "reference": "0ea0839406ad6bf03fe008ef0016541629860fcb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti-pci/zipball/077e39864918aa8e50bc98e1017943a7f345d820",
-                "reference": "077e39864918aa8e50bc98e1017943a7f345d820",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti-pci/zipball/0ea0839406ad6bf03fe008ef0016541629860fcb",
+                "reference": "0ea0839406ad6bf03fe008ef0016541629860fcb",
                 "shasum": ""
             },
             "require": {
@@ -4164,9 +4164,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-tao-itemqti-pci/issues",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti-pci/tree/v8.3.0"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti-pci/tree/v8.3.1"
             },
-            "time": "2022-09-07T12:10:13+00:00"
+            "time": "2022-09-08T13:27:43+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pic",


### PR DESCRIPTION
Update oat-sa/extension-tao-itemqti-pci to version 8.3.1

**Release notes :**
 - _Fix_ [TR-4575](https://oat-sa.atlassian.net/browse/TR-4575) : Revert a fix breaking compliance with the IMS standard [#320](https://github.com/oat-sa/extension-tao-itemqti-pci/pull/320)
