### PR TITLE
fix: update "oat-sa/extension-tao-itemqti" to  "29.12.4.3"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "oat-sa/extension-tao-community": "10.3.0",
         "oat-sa/extension-tao-funcacl": "7.2.1",
         "oat-sa/extension-tao-dac-simple": "7.7.2",
-        "oat-sa/extension-tao-itemqti": "29.12.4.2",
+        "oat-sa/extension-tao-itemqti": "29.12.4.3",
         "oat-sa/extension-tao-testqti": "44.21.1.1",
         "oat-sa/extension-tao-testtaker": "8.9.2",
         "oat-sa/extension-tao-group": "7.6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "202a13a80cb0ae554cf91d56936ad4d2",
+    "content-hash": "d534ce3bdb30fe692bdedab524c787a4",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4026,16 +4026,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.12.4.2",
+            "version": "v29.12.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "0a20b185776a01a5b2836a8b08f26840b31eff9a"
+                "reference": "68f98b8b65e0dee75b9fc9f607f33b531f3f5828"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/0a20b185776a01a5b2836a8b08f26840b31eff9a",
-                "reference": "0a20b185776a01a5b2836a8b08f26840b31eff9a",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/68f98b8b65e0dee75b9fc9f607f33b531f3f5828",
+                "reference": "68f98b8b65e0dee75b9fc9f607f33b531f3f5828",
                 "shasum": ""
             },
             "require": {
@@ -4115,9 +4115,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.12.4.2"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.12.4.3"
             },
-            "time": "2022-10-10T14:48:01+00:00"
+            "time": "2022-10-19T14:40:13+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1910

**Release 2022.10.07**

Update "oat-sa/extension-tao-itemqti" to  ["29.12.4.3"](https://github.com/oat-sa/extension-tao-itemqti/releases/tag/v29.12.4.3)

Backport of https://github.com/oat-sa/extension-tao-itemqti/releases/tag/v29.14.4 to October release 