### PR TITLE
fix: remove mainClass from user-styles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "oat-sa/extension-tao-lti": "15.9.1",
         "oat-sa/extension-tao-ltideliveryprovider": "12.12.3",
         "oat-sa/extension-tao-revision": "10.4.0",
-        "oat-sa/extension-tao-mediamanager": "12.31.2.2",
+        "oat-sa/extension-tao-mediamanager": "12.31.2.3",
         "oat-sa/extension-pcisample": "3.6.1",
         "oat-sa/extension-tao-backoffice": "6.11.2",
         "oat-sa/extension-tao-proctoring": "20.5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3792a696c7e46ff822281c1a38d484c6",
+    "content-hash": "0d10ff81e4bd525fed90e1d4a8cfe870",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4391,16 +4391,16 @@
         },
         {
             "name": "oat-sa/extension-tao-mediamanager",
-            "version": "v12.31.2.2",
+            "version": "v12.31.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-mediamanager.git",
-                "reference": "e7161f96aa0f41c195fef29a23229cf0f8686591"
+                "reference": "3b64b986d12da0d537c762a22405b81df98f390a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-mediamanager/zipball/e7161f96aa0f41c195fef29a23229cf0f8686591",
-                "reference": "e7161f96aa0f41c195fef29a23229cf0f8686591",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-mediamanager/zipball/3b64b986d12da0d537c762a22405b81df98f390a",
+                "reference": "3b64b986d12da0d537c762a22405b81df98f390a",
                 "shasum": ""
             },
             "require": {
@@ -4443,9 +4443,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-mediamanager/tree/v12.31.2.2"
+                "source": "https://github.com/oat-sa/extension-tao-mediamanager/tree/v12.31.2.3"
             },
-            "time": "2022-10-21T13:32:32+00:00"
+            "time": "2022-10-25T11:24:56+00:00"
         },
         {
             "name": "oat-sa/extension-tao-outcome",


### PR DESCRIPTION
Backport to fix Assets with Styles:

Remove `mainClass` on Asset at saving: 
- https://github.com/oat-sa/extension-tao-mediamanager/pull/441
- https://github.com/oat-sa/extension-tao-mediamanager/pull/444

Fix the CSS format https://github.com/oat-sa/extension-tao-mediamanager/pull/421/commits/f50565216708c1770b647c333f12bdcba58688e3