### PR TITLE
Hotfix/REL-879/downgrade minimal browser support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "prefer-stable": true,
   "require": {
         "oat-sa/generis": "15.20.4",
-        "oat-sa/tao-core": "50.23.0.2",
+        "oat-sa/tao-core": "dev-hotfix/REL-879/downgrade-minimal-browser-support as 50.23.0.3",
         "oat-sa/extension-tao-community": "10.3.0",
         "oat-sa/extension-tao-funcacl": "7.2.1",
         "oat-sa/extension-tao-dac-simple": "7.7.2",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "prefer-stable": true,
   "require": {
         "oat-sa/generis": "15.20.4",
-        "oat-sa/tao-core": "dev-hotfix/REL-879/downgrade-minimal-browser-support as 50.23.0.3",
+        "oat-sa/tao-core": "50.23.0.3",
         "oat-sa/extension-tao-community": "10.3.0",
         "oat-sa/extension-tao-funcacl": "7.2.1",
         "oat-sa/extension-tao-dac-simple": "7.7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d10ff81e4bd525fed90e1d4a8cfe870",
+    "content-hash": "348936f1e79b804c6c945021ef8d79fd",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -5926,16 +5926,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v50.23.0.2",
+            "version": "dev-hotfix/REL-879/downgrade-minimal-browser-support",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "07e7062747f7f4e298bc09dfcb7cb9a8d7a65f29"
+                "reference": "d3a1c5184652219b0d531f48b9ccd47bfc772aab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/07e7062747f7f4e298bc09dfcb7cb9a8d7a65f29",
-                "reference": "07e7062747f7f4e298bc09dfcb7cb9a8d7a65f29",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/d3a1c5184652219b0d531f48b9ccd47bfc772aab",
+                "reference": "d3a1c5184652219b0d531f48b9ccd47bfc772aab",
                 "shasum": ""
             },
             "require": {
@@ -6037,9 +6037,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v50.23.0.2"
+                "source": "https://github.com/oat-sa/tao-core/tree/hotfix/REL-879/downgrade-minimal-browser-support"
             },
-            "time": "2022-10-12T12:12:34+00:00"
+            "time": "2022-10-25T15:00:13+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -9545,9 +9545,18 @@
         }
     ],
     "packages-dev": [],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "oat-sa/tao-core",
+            "version": "dev-hotfix/REL-879/downgrade-minimal-browser-support",
+            "alias": "50.23.0.3",
+            "alias_normalized": "50.23.0.3"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "oat-sa/tao-core": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
@@ -9555,5 +9564,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "348936f1e79b804c6c945021ef8d79fd",
+    "content-hash": "1f63c5c729511612731ce8f2094d8d6c",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -5926,16 +5926,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "dev-hotfix/REL-879/downgrade-minimal-browser-support",
+            "version": "v50.23.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "d3a1c5184652219b0d531f48b9ccd47bfc772aab"
+                "reference": "83899c2f96cc040e5a7b4c498039df96530f5395"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/d3a1c5184652219b0d531f48b9ccd47bfc772aab",
-                "reference": "d3a1c5184652219b0d531f48b9ccd47bfc772aab",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/83899c2f96cc040e5a7b4c498039df96530f5395",
+                "reference": "83899c2f96cc040e5a7b4c498039df96530f5395",
                 "shasum": ""
             },
             "require": {
@@ -6037,9 +6037,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/hotfix/REL-879/downgrade-minimal-browser-support"
+                "source": "https://github.com/oat-sa/tao-core/tree/v50.23.0.3"
             },
-            "time": "2022-10-25T15:00:13+00:00"
+            "time": "2022-10-25T15:21:07+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -9545,18 +9545,9 @@
         }
     ],
     "packages-dev": [],
-    "aliases": [
-        {
-            "package": "oat-sa/tao-core",
-            "version": "dev-hotfix/REL-879/downgrade-minimal-browser-support",
-            "alias": "50.23.0.3",
-            "alias_normalized": "50.23.0.3"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "oat-sa/tao-core": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/REF-879

### Summary

Fix a runtime issue with wkhtmltopdf.
See: https://github.com/oat-sa/tao-core/pull/3653

The drop of IE support removed the transpilation to ES5. While this is fine for the modern browsers we support, it has an impact on the taoBooklet feature which is relying on wkhtmltopdf. This tool does not support ES6.

We need to temporarily downgrade the bundler to a version that generates ES5. 

### Details

Several libraries have been reverted:
- `@oat-sa/browserslist-config-tao` to version `0.3.1` (was `1.0.1`)
- `@oat-sa/grunt-tao-bundle` to version `0.6.1` (was `0.7.0`)
- `@oat-sa/tao-core-sdk` to version `1.19.2` (was `1.20.0`)

These downgrades fortunately only contain the change for the bundler. Event for `tao-core-sdk`.

### How to test
- checkout the branch
- play with TAO
- take test
- generate a booklet