### PR TITLE
fix: backport for AUT-2716

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "oat-sa/extension-tao-community": "10.3.1",
     "oat-sa/extension-tao-funcacl": "7.2.2",
     "oat-sa/extension-tao-dac-simple": "7.7.4",
-    "oat-sa/extension-tao-itemqti": "29.14.4.2",
+    "oat-sa/extension-tao-itemqti": "29.14.4.3",
     "oat-sa/extension-tao-testqti": "44.22.6",
     "oat-sa/extension-tao-testtaker": "8.9.3",
     "oat-sa/extension-tao-group": "7.6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f572cd0fd09244760793b060971124bd",
+    "content-hash": "3e5074ca1a3e1e02664d06e6529542ae",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4111,16 +4111,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.14.4.2",
+            "version": "29.14.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "3bde5ad716844299eb5ef3d4e7a05b21c447efd7"
+                "reference": "00ffe6dfe40129f6409096f69bdc99103f86f7d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/3bde5ad716844299eb5ef3d4e7a05b21c447efd7",
-                "reference": "3bde5ad716844299eb5ef3d4e7a05b21c447efd7",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/00ffe6dfe40129f6409096f69bdc99103f86f7d9",
+                "reference": "00ffe6dfe40129f6409096f69bdc99103f86f7d9",
                 "shasum": ""
             },
             "require": {
@@ -4197,9 +4197,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.14.4.2"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/29.14.4.3"
             },
-            "time": "2022-11-14T14:34:31+00:00"
+            "time": "2022-11-15T11:47:05+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",
@@ -11647,5 +11647,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Backport to nov release for AUT-2716 [https://oat-sa.atlassian.net/browse/AUT-2716](https://github.com/oat-sa/tao-community/pull/url)