### PR TITLE
fix: version attribute removed of the success response of the endpoint updateMetadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "oat-sa/extension-tao-funcacl": "7.2.2",
     "oat-sa/extension-tao-dac-simple": "7.7.7",
     "oat-sa/extension-tao-itemqti": "29.20.2",
-    "oat-sa/extension-tao-testqti": "dev-release-2023-02 as 45.0.7",
+    "oat-sa/extension-tao-testqti": "45.0.7",
     "oat-sa/extension-tao-testtaker": "8.9.4",
     "oat-sa/extension-tao-group": "7.6.3",
     "oat-sa/extension-tao-item": "11.32.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2e7aa8e79385c233bb0e88b89f02a03",
+    "content-hash": "717b22237da8b19e9f9cde853bdfb5ea",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -5177,16 +5177,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti",
-            "version": "dev-release-2023-02",
+            "version": "45.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "bce85ed96604ad6532d5d87b5e813290a9cb488c"
+                "reference": "d891bddd80e08349f68840eb6e62462e6b8719d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/bce85ed96604ad6532d5d87b5e813290a9cb488c",
-                "reference": "bce85ed96604ad6532d5d87b5e813290a9cb488c",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/d891bddd80e08349f68840eb6e62462e6b8719d6",
+                "reference": "d891bddd80e08349f68840eb6e62462e6b8719d6",
                 "shasum": ""
             },
             "require": {
@@ -5270,9 +5270,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/backport/PISA25-269/endpoint-update-metada-is-not-indexing-metadata-on-advanced-search"
+                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/45.0.7"
             },
-            "time": "2023-01-23T11:11:12+00:00"
+            "time": "2023-01-23T12:59:28+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
@@ -11637,12 +11637,6 @@
     ],
     "aliases": [
         {
-            "package": "oat-sa/extension-tao-testqti",
-            "version": "dev-release-2023-02",
-            "alias": "45.0.7",
-            "alias_normalized": "45.0.7.0"
-        },
-        {
             "package": "phpdocumentor/reflection-docblock",
             "version": "5.3.0.0",
             "alias": "2.0.5",
@@ -11650,9 +11644,7 @@
         }
     ],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "oat-sa/extension-tao-testqti": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],


### PR DESCRIPTION
Using Release instead of inline alias on dependency oat-sa/extension-tao-testqti