### PR TITLE
fix: backport LSI-1770 for missing Italian translations (diag)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "oat-sa/extension-pcisample": "3.6.4",
     "oat-sa/extension-tao-backoffice": "6.11.3",
     "oat-sa/extension-tao-proctoring": "20.5.5",
-    "oat-sa/extension-tao-clientdiag": "8.4.5",
+    "oat-sa/extension-tao-clientdiag": "8.4.6",
     "oat-sa/extension-tao-eventlog": "3.3.3",
     "oat-sa/extension-tao-task-queue": "6.6.3",
     "oat-sa/extension-tao-testqti-previewer": "3.7.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa0e2408d460d282526263238187c144",
+    "content-hash": "3e99128572959995a9b41e7b9f3d1bb4",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3469,16 +3469,16 @@
         },
         {
             "name": "oat-sa/extension-tao-clientdiag",
-            "version": "v8.4.5",
+            "version": "v8.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-clientdiag.git",
-                "reference": "7b9b9c1f3b9b5566937062cff0d0061d4e9efd0e"
+                "reference": "2cb19502dbaa55e7df464bf08f7521c9075b8f54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-clientdiag/zipball/7b9b9c1f3b9b5566937062cff0d0061d4e9efd0e",
-                "reference": "7b9b9c1f3b9b5566937062cff0d0061d4e9efd0e",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-clientdiag/zipball/2cb19502dbaa55e7df464bf08f7521c9075b8f54",
+                "reference": "2cb19502dbaa55e7df464bf08f7521c9075b8f54",
                 "shasum": ""
             },
             "require": {
@@ -3514,9 +3514,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-tao-clientdiag/issues",
-                "source": "https://github.com/oat-sa/extension-tao-clientdiag/tree/v8.4.5"
+                "source": "https://github.com/oat-sa/extension-tao-clientdiag/tree/v8.4.6"
             },
-            "time": "2022-09-29T11:53:32+00:00"
+            "time": "2023-02-01T11:25:38+00:00"
         },
         {
             "name": "oat-sa/extension-tao-community",


### PR DESCRIPTION
This backport aims at implementing [LSI-1770](https://oat-sa.atlassian.net/browse/LSI-1770) and [LSI-1771](https://oat-sa.atlassian.net/browse/LSI-1771) in 2022 November release.

[LSI-1770]: https://oat-sa.atlassian.net/browse/LSI-1770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LSI-1771]: https://oat-sa.atlassian.net/browse/LSI-1771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ