### PR TITLE
fix: add version 29.21.0 with html clean up functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "oat-sa/extension-tao-community": "10.3.1",
     "oat-sa/extension-tao-funcacl": "7.2.2",
     "oat-sa/extension-tao-dac-simple": "7.7.8",
-    "oat-sa/extension-tao-itemqti": "29.20.4",
+    "oat-sa/extension-tao-itemqti": "29.21.0",
     "oat-sa/extension-tao-testqti": "45.1.5",
     "oat-sa/extension-tao-testtaker": "8.9.4",
     "oat-sa/extension-tao-group": "7.6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "90359fc6064e72c64744d8ab9dd6d86c",
+    "content-hash": "38f8c68e63bd4ac44bdc3747495aa250",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4115,16 +4115,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.20.4",
+            "version": "v29.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "57050aa66df4fa19014ba2786690bfcfa8db0d92"
+                "reference": "20bc2e3ef2550cf4a11c696f158bad6be64f0e4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/57050aa66df4fa19014ba2786690bfcfa8db0d92",
-                "reference": "57050aa66df4fa19014ba2786690bfcfa8db0d92",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/20bc2e3ef2550cf4a11c696f158bad6be64f0e4c",
+                "reference": "20bc2e3ef2550cf4a11c696f158bad6be64f0e4c",
                 "shasum": ""
             },
             "require": {
@@ -4201,9 +4201,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.20.4"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.21.0"
             },
-            "time": "2023-02-07T10:20:37+00:00"
+            "time": "2023-02-20T10:46:31+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
Enable new html tags functionality for March release of Tao community. 