### PR TITLE
[BACKPORT] [NSA-353] cli exports are missing critical fields #461

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "oat-sa/extension-tao-itemqti-pic": "6.4.0",
         "oat-sa/extension-tao-test": "15.13.0",
         "oat-sa/extension-tao-outcome": "13.2.0",
-        "oat-sa/extension-tao-outcomeui": "11.1.2.1",
+        "oat-sa/extension-tao-outcomeui": "11.1.2.2",
         "oat-sa/extension-tao-outcomerds": "8.2.0",
         "oat-sa/extension-tao-outcomekeyvalue": "6.1.1",
         "oat-sa/extension-tao-outcomelti": "5.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6baa4ff51e9e6049ee9a5cfaedd8bb5",
+    "content-hash": "5d55f0451c3fa91690bc1e725fd54b53",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4527,16 +4527,16 @@
         },
         {
             "name": "oat-sa/extension-tao-outcomeui",
-            "version": "v11.1.2.1",
+            "version": "11.1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-outcomeui.git",
-                "reference": "1e2328cc8311516830e74f7b8734b0c6ed11d7fd"
+                "reference": "892f1ada3bbf37c2833935e7b7aaebffa88844ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-outcomeui/zipball/1e2328cc8311516830e74f7b8734b0c6ed11d7fd",
-                "reference": "1e2328cc8311516830e74f7b8734b0c6ed11d7fd",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-outcomeui/zipball/892f1ada3bbf37c2833935e7b7aaebffa88844ec",
+                "reference": "892f1ada3bbf37c2833935e7b7aaebffa88844ec",
                 "shasum": ""
             },
             "require": {
@@ -4608,9 +4608,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-outcomeui/tree/v11.1.2.1"
+                "source": "https://github.com/oat-sa/extension-tao-outcomeui/tree/11.1.2.2"
             },
-            "time": "2022-12-20T13:55:28+00:00"
+            "time": "2023-02-23T09:20:34+00:00"
         },
         {
             "name": "oat-sa/extension-tao-proctoring",


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/NSA-353

## What's Changed

The reason which caused this issue is the ticket RE-255 which was supposed to fix an issue on the export UI. The side effect was that the fields were also removed from CLI. Now both bugs should be fixed with these changes
 
Refs: https://oat-sa.atlassian.net/browse/RE-255
Refs: https://oat-sa.atlassian.net/browse/NSA-353

## How to test
- please check: https://oat-sa.atlassian.net/browse/RE-255
- please check: https://oat-sa.atlassian.net/browse/NSA-353