### PR TITLE
Hotfix/OATSD-2361/inline choice compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "oat-sa/extension-tao-community": "10.3.1",
     "oat-sa/extension-tao-funcacl": "7.2.2",
     "oat-sa/extension-tao-dac-simple": "7.7.7",
-    "oat-sa/extension-tao-itemqti": "29.20.3",
+    "oat-sa/extension-tao-itemqti": "29.20.3.1",
     "oat-sa/extension-tao-testqti": "45.0.7",
     "oat-sa/extension-tao-testtaker": "8.9.4",
     "oat-sa/extension-tao-group": "7.6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c46598d80bf63bf9fa7581bdd24fa84",
+    "content-hash": "22b0f9d593677965285fd1d1290d3be4",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4115,16 +4115,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.20.3",
+            "version": "v29.20.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "e5e07191ac95776a361cf02c44752a97123b630d"
+                "reference": "bb54f44c885fc51d78bfb9f6b17b7f15832a5596"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/e5e07191ac95776a361cf02c44752a97123b630d",
-                "reference": "e5e07191ac95776a361cf02c44752a97123b630d",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/bb54f44c885fc51d78bfb9f6b17b7f15832a5596",
+                "reference": "bb54f44c885fc51d78bfb9f6b17b7f15832a5596",
                 "shasum": ""
             },
             "require": {
@@ -4201,9 +4201,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.20.3"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.20.3.1"
             },
-            "time": "2023-01-26T10:47:18+00:00"
+            "time": "2023-02-24T14:56:58+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
# [OATSD-2361](https://oat-sa.atlassian.net/browse/OATSD-2361)

Backport of https://github.com/oat-sa/extension-tao-itemqti/pull/2327

This PR aims to fix `inlineChoice`'s compatibility with its older data format relying on `text` attribute while keeping the new implementation relying on the `body` element.

https://user-images.githubusercontent.com/2943256/221191076-4bea3b63-1c02-4e7f-ad43-620dc5e4a284.mov

[OATSD-2361]: https://oat-sa.atlassian.net/browse/OATSD-2361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ