### PR TITLE
Hotfix/OATSD-2361/2023.03/inline choice compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "oat-sa/extension-tao-community": "10.3.1",
     "oat-sa/extension-tao-funcacl": "7.2.2",
     "oat-sa/extension-tao-dac-simple": "7.7.8",
-    "oat-sa/extension-tao-itemqti": "29.21.0",
+    "oat-sa/extension-tao-itemqti": "29.21.0.1",
     "oat-sa/extension-tao-testqti": "45.1.5",
     "oat-sa/extension-tao-testtaker": "8.9.4",
     "oat-sa/extension-tao-group": "7.6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38f8c68e63bd4ac44bdc3747495aa250",
+    "content-hash": "f398707675de4c98ffb6937187e3b622",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4115,16 +4115,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.21.0",
+            "version": "v29.21.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "20bc2e3ef2550cf4a11c696f158bad6be64f0e4c"
+                "reference": "e804cbbce1064d3b2d5ed19550370ab3e4632597"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/20bc2e3ef2550cf4a11c696f158bad6be64f0e4c",
-                "reference": "20bc2e3ef2550cf4a11c696f158bad6be64f0e4c",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/e804cbbce1064d3b2d5ed19550370ab3e4632597",
+                "reference": "e804cbbce1064d3b2d5ed19550370ab3e4632597",
                 "shasum": ""
             },
             "require": {
@@ -4201,9 +4201,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.21.0"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.21.0.1"
             },
-            "time": "2023-02-20T10:46:31+00:00"
+            "time": "2023-02-24T16:09:15+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",
@@ -11648,5 +11648,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
# [OATSD-2361](https://oat-sa.atlassian.net/browse/OATSD-2361)

Backport of https://github.com/oat-sa/extension-tao-itemqti/pull/2327

This PR aims to fix `inlineChoice`'s compatibility with its older data format relying on `text` attribute while keeping the new implementation relying on the `body` element.

https://user-images.githubusercontent.com/2943256/221191076-4bea3b63-1c02-4e7f-ad43-620dc5e4a284.mov

[OATSD-2361]: https://oat-sa.atlassian.net/browse/OATSD-2361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ