### PR TITLE
Fix – Eliminate ci workflow deprecations

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    concurrency: ci-${{ github.ref }}
+    concurrency: ci-${{ matrix.php-version }}-${{ github.ref }}
     runs-on: ${{ matrix.operating-system }}
     if: "!contains(github.event.head_commit.message, 'ci: add updated coverage_badge.svg')"
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -70,7 +70,7 @@ jobs:
         run: echo formatted='[🔗 Coverage report](https://oat-sa.github.io/tao-community/${{ github.head_ref || github.ref_name }})' >> $GITHUB_OUTPUT
 
       - name: Job summary
-        uses: mathiasvr/command-output@v1
+        uses: mathiasvr/command-output@v2.0.0
         id: summary
         with:
           run: |

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Build coverage report link
         id: report-link
         if: ${{ matrix.coverage }}
-        run: echo ::set-output name=formatted::'[🔗 Coverage report](https://oat-sa.github.io/tao-community/${{ github.head_ref || github.ref_name }})'
+        run: echo formatted='[🔗 Coverage report](https://oat-sa.github.io/tao-community/${{ github.head_ref || github.ref_name }})' >> $GITHUB_OUTPUT
 
       - name: Job summary
         uses: mathiasvr/command-output@v1


### PR DESCRIPTION
This PR addresses the following deprecations in the GitHub Actions workflow
1. https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12
2. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands

It also fixes unwanted concurrent jobs cancellations.

**Before**
<img width="1417" alt="image" src="https://user-images.githubusercontent.com/2943256/225388549-a6b7f23f-924d-4cd6-b540-bf28e5a097d3.png">