### PR TITLE
Backport for Ims Pci export fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "oat-sa/extension-tao-testtaker": "8.6.0",
         "oat-sa/extension-tao-group": "7.5.0",
         "oat-sa/extension-tao-item": "11.16.1",
-        "oat-sa/extension-tao-itemqti-pci": "7.7.2.3",
+        "oat-sa/extension-tao-itemqti-pci": "7.7.2.4",
         "oat-sa/extension-tao-itemqti": "28.19.14.9",
         "oat-sa/extension-tao-itemqti-pic": "6.1.0",
         "oat-sa/extension-tao-test": "15.7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa5353dd3fb900a0019aea186dd51d19",
+    "content-hash": "e9bf7146a3d2c7ae37ace33a3fe48f51",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3678,16 +3678,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",
-            "version": "v7.7.2.3",
+            "version": "v7.7.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti-pci.git",
-                "reference": "89c96fa30351c0bfeaeeeab7a540db4fc09d52e1"
+                "reference": "d0f9f40d51cd9633c4d70c18c8b27b23aab335c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti-pci/zipball/89c96fa30351c0bfeaeeeab7a540db4fc09d52e1",
-                "reference": "89c96fa30351c0bfeaeeeab7a540db4fc09d52e1",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti-pci/zipball/d0f9f40d51cd9633c4d70c18c8b27b23aab335c5",
+                "reference": "d0f9f40d51cd9633c4d70c18c8b27b23aab335c5",
                 "shasum": ""
             },
             "require": {
@@ -3721,9 +3721,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-tao-itemqti-pci/issues",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti-pci/tree/v7.7.2.3"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti-pci/tree/v7.7.2.4"
             },
-            "time": "2022-12-13T12:55:37+00:00"
+            "time": "2023-03-21T11:10:11+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pic",


### PR DESCRIPTION
This PR aim to provide proper ims pic export into older version of package

reason - https://oat-sa.atlassian.net/browse/OATSD-2386?focusedCommentId=220578
target releases:
- https://github.com/oat-sa/tao-enterprise-depp/releases/tag/v2021.11.50

