### PR TITLE
fix: squash gh-pages history

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -124,6 +124,8 @@ jobs:
         with:
           folder: clover
           target-folder: ${{ github.head_ref || github.ref_name }}
+          single-commit: true
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
 
       - name: Job summary
         run: echo "${{ steps.summary.outputs.stdout }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This PR squashes the whole https://github.com/oat-sa/tao-community/tree/gh-pages history into a single commit, so that the changes' history gets garbage collected and doesn't require additional disk space.