### PR TITLE
chore: updates item qti version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "oat-sa/extension-tao-community": "10.3.1",
     "oat-sa/extension-tao-funcacl": "7.2.2",
     "oat-sa/extension-tao-dac-simple": "7.8.0",
-    "oat-sa/extension-tao-itemqti": "29.21.5",
+    "oat-sa/extension-tao-itemqti": "29.22.0",
     "oat-sa/extension-tao-testqti": "45.2.2",
     "oat-sa/extension-tao-testtaker": "8.10.0",
     "oat-sa/extension-tao-group": "7.6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7cbdb59c845e8c5878ff95cb03a23a9",
+    "content-hash": "8b178b799d4b58d7da9822a399b4d585",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4115,16 +4115,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.21.5",
+            "version": "v29.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "98e0fb7dd29368a2e5c8afc04d28c00b87f03070"
+                "reference": "20c5bbfec57e84e8d88c35df8b0ca0fa9e06ec4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/98e0fb7dd29368a2e5c8afc04d28c00b87f03070",
-                "reference": "98e0fb7dd29368a2e5c8afc04d28c00b87f03070",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/20c5bbfec57e84e8d88c35df8b0ca0fa9e06ec4b",
+                "reference": "20c5bbfec57e84e8d88c35df8b0ca0fa9e06ec4b",
                 "shasum": ""
             },
             "require": {
@@ -4201,9 +4201,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.21.5"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.22.0"
             },
-            "time": "2023-04-05T13:37:42+00:00"
+            "time": "2023-04-11T14:52:43+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
coming from [https://oat-sa.atlassian.net/browse/AUT-3027](https://oat-sa.atlassian.net/browse/AUT-3027)

changes:
* updates tao-qti-item extension to avoid overflow on long strings and math expressions 