### PR TITLE
hotfix: use flag to skip replaceNonBreakingSpaceCharacters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "oat-sa/extension-tao-community": "10.3.1",
     "oat-sa/extension-tao-funcacl": "7.2.2",
     "oat-sa/extension-tao-dac-simple": "7.7.8",
-    "oat-sa/extension-tao-itemqti": "29.21.2",
+    "oat-sa/extension-tao-itemqti": "29.21.2.1",
     "oat-sa/extension-tao-testqti": "45.2.0",
     "oat-sa/extension-tao-testtaker": "8.9.4",
     "oat-sa/extension-tao-group": "7.6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "00e53da3d7985701c32822ed34e82999",
+    "content-hash": "9e376c5473dc6273142e670329de1310",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4115,16 +4115,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.21.2",
+            "version": "v29.21.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "0696c742c7c3059d43698cbb895af117d8bf0150"
+                "reference": "029f06e4e954fbe6bddf3cad62128e8afd3fc9c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/0696c742c7c3059d43698cbb895af117d8bf0150",
-                "reference": "0696c742c7c3059d43698cbb895af117d8bf0150",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/029f06e4e954fbe6bddf3cad62128e8afd3fc9c7",
+                "reference": "029f06e4e954fbe6bddf3cad62128e8afd3fc9c7",
                 "shasum": ""
             },
             "require": {
@@ -4201,9 +4201,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.21.2"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.21.2.1"
             },
-            "time": "2023-02-24T14:23:32+00:00"
+            "time": "2023-04-12T13:20:48+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
Backport of https://github.com/oat-sa/extension-tao-itemqti/pull/2341 to [April "oat-sa/extension-tao-itemqti": "29.21.2"](https://github.com/oat-sa/tao-community/blob/2023.04/composer.json#L39) release