### PR TITLE
backport: add fixess for MCA

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "oat-sa/extension-tao-community": "10.3.1",
     "oat-sa/extension-tao-funcacl": "7.2.2",
     "oat-sa/extension-tao-dac-simple": "7.7.8",
-    "oat-sa/extension-tao-itemqti": "29.21.2.1",
+    "oat-sa/extension-tao-itemqti": "29.21.2.2",
     "oat-sa/extension-tao-testqti": "45.2.0",
     "oat-sa/extension-tao-testtaker": "8.9.4",
     "oat-sa/extension-tao-group": "7.6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "093928b713e4f44419d176c8d5656001",
+    "content-hash": "e57d7d2e5d6275fe56bee44d24343bac",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -4115,16 +4115,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v29.21.2.1",
+            "version": "v29.21.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "029f06e4e954fbe6bddf3cad62128e8afd3fc9c7"
+                "reference": "416339692f6d4748adfbf5731f91e722dad0b080"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/029f06e4e954fbe6bddf3cad62128e8afd3fc9c7",
-                "reference": "029f06e4e954fbe6bddf3cad62128e8afd3fc9c7",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/416339692f6d4748adfbf5731f91e722dad0b080",
+                "reference": "416339692f6d4748adfbf5731f91e722dad0b080",
                 "shasum": ""
             },
             "require": {
@@ -4201,9 +4201,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.21.2.1"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v29.21.2.2"
             },
-            "time": "2023-04-12T13:20:48+00:00"
+            "time": "2023-04-18T16:03:51+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",
@@ -11648,5 +11648,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Backport: https://github.com/oat-sa/extension-tao-itemqti/pull/2334

fixes overflow on associate interaction
if choice contains mathjax, it will stretch
images will now be limited to 180px max-width by CSS

Backport: https://github.com/oat-sa/extension-tao-itemqti/pull/2332

We are using JQuery UI draggable v1.9.2, that has issue with RTL https://bugs.jqueryui.com/ticket/4994
We can't update it, because we use JQuery lib v1.9.1

Fix: pass dir=rtl to widget inside columns and set dir=ltr for grid by css - see views/scss/item-creator.scss
Fix: clean code in views/js/qtiCreator/editor/gridEditor/resizable.js

