### PR TITLE
fix: update funcacl commit to do not add bundles

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3865,12 +3865,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-funcacl.git",
-                "reference": "ad7276c45ef81d7f7a2a72e3221aa3122001e94e"
+                "reference": "ab7a776db6c22e10b308f8f7a493abd9deb2afa4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-funcacl/zipball/ad7276c45ef81d7f7a2a72e3221aa3122001e94e",
-                "reference": "ad7276c45ef81d7f7a2a72e3221aa3122001e94e",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-funcacl/zipball/ab7a776db6c22e10b308f8f7a493abd9deb2afa4",
+                "reference": "ab7a776db6c22e10b308f8f7a493abd9deb2afa4",
                 "shasum": ""
             },
             "require": {
@@ -3939,7 +3939,7 @@
                 "issues": "http://forge.taotesting.com",
                 "source": "https://github.com/oat-sa/extension-tao-funcacl/tree/v7.2.2.1"
             },
-            "time": "2023-05-04T20:57:09+00:00"
+            "time": "2023-05-05T16:16:48+00:00"
         },
         {
             "name": "oat-sa/extension-tao-group",


### PR DESCRIPTION
## What's changed 

Update funcacl to new version withou any js bundles in it, only translations.
More info: https://github.com/oat-sa/extension-tao-funcacl/commit/4fbc4289df577384127866127b44422f1e26a53f