### PR TITLE
chore: backport ADF-1571 fix to september release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "prefer-stable": true,
   "require": {
     "oat-sa/generis": "15.27.0",
-    "oat-sa/tao-core": "53.4.2",
+    "oat-sa/tao-core": "53.6.0",
     "oat-sa/extension-tao-community": "11.0.4",
     "oat-sa/extension-tao-funcacl": "7.4.0",
     "oat-sa/extension-tao-dac-simple": "7.10.5",
@@ -60,7 +60,7 @@
     "oat-sa/extension-tao-proctoring": "20.7.1",
     "oat-sa/extension-tao-clientdiag": "8.5.1",
     "oat-sa/extension-tao-eventlog": "3.4.1",
-    "oat-sa/extension-tao-task-queue": "6.7.2",
+    "oat-sa/extension-tao-task-queue": "6.8.2",
     "oat-sa/extension-tao-testqti-previewer": "3.9.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52191d8b30966bc7b6a7ca0e9028f69b",
+    "content-hash": "1848b94aca3a1a5f21a4a414112fa802",
     "packages": [
         {
             "name": "clearfw/clearfw",
@@ -4865,16 +4865,16 @@
         },
         {
             "name": "oat-sa/extension-tao-task-queue",
-            "version": "v6.7.2",
+            "version": "v6.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-task-queue.git",
-                "reference": "ba03e4f41f6fa4c6ce4d04bc62011e7e90573f32"
+                "reference": "0fbc8d13f4059df759ec575ede26db427bc2935c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-task-queue/zipball/ba03e4f41f6fa4c6ce4d04bc62011e7e90573f32",
-                "reference": "ba03e4f41f6fa4c6ce4d04bc62011e7e90573f32",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-task-queue/zipball/0fbc8d13f4059df759ec575ede26db427bc2935c",
+                "reference": "0fbc8d13f4059df759ec575ede26db427bc2935c",
                 "shasum": ""
             },
             "require": {
@@ -4882,7 +4882,7 @@
                 "ext-pdo": "*",
                 "oat-sa/generis": ">=15.22",
                 "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-                "oat-sa/tao-core": ">=50.24.6",
+                "oat-sa/tao-core": ">=53.6.0||53.3.3",
                 "react/child-process": "^0.5.2"
             },
             "type": "tao-extension",
@@ -4919,9 +4919,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-tao-task-queue/issues",
-                "source": "https://github.com/oat-sa/extension-tao-task-queue/tree/v6.7.2"
+                "source": "https://github.com/oat-sa/extension-tao-task-queue/tree/v6.8.2"
             },
-            "time": "2023-06-02T15:13:31+00:00"
+            "time": "2023-09-01T08:52:46+00:00"
         },
         {
             "name": "oat-sa/extension-tao-test",
@@ -5887,16 +5887,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v53.4.2",
+            "version": "v53.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "0b62b5a20e86e8b11a7b91bcec1c94749a3e4c98"
+                "reference": "57ae1b464c07479f8c86bbfa249d15c4e44cfa8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/0b62b5a20e86e8b11a7b91bcec1c94749a3e4c98",
-                "reference": "0b62b5a20e86e8b11a7b91bcec1c94749a3e4c98",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/57ae1b464c07479f8c86bbfa249d15c4e44cfa8f",
+                "reference": "57ae1b464c07479f8c86bbfa249d15c4e44cfa8f",
                 "shasum": ""
             },
             "require": {
@@ -5997,9 +5997,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v53.4.2"
+                "source": "https://github.com/oat-sa/tao-core/tree/v53.6.0"
             },
-            "time": "2023-08-07T08:16:28+00:00"
+            "time": "2023-08-31T11:54:11+00:00"
         },
         {
             "name": "paragonie/random_compat",


### PR DESCRIPTION
# [ADF-1571](https://oat-sa.atlassian.net/browse/ADF-1571)

## Backports
### oat-sa/tao-core
* [v53.6.0](https://github.com/oat-sa/tao-core/releases/tag/v53.6.0)
  * https://github.com/oat-sa/tao-core/pull/3875
    * https://github.com/oat-sa/tao-core/compare/v53.4.2...v53.6.1

### oat-sa/extension-tao-task-queue
* [v6.8.1](https://github.com/oat-sa/extension-tao-task-queue/releases/tag/v6.8.1)
  * https://github.com/oat-sa/extension-tao-task-queue/pull/171
* [v6.8.2](https://github.com/oat-sa/extension-tao-task-queue/releases/tag/v6.8.2)
  * https://github.com/oat-sa/extension-tao-task-queue/pull/171

## Features/fixes to be included
### oat-sa/tao-core
* [v53.4.3](https://github.com/oat-sa/tao-core/releases/tag/v53.4.3)
  * https://github.com/oat-sa/tao-core/pull/3867
* [v53.4.4](https://github.com/oat-sa/tao-core/releases/tag/v53.4.4)
  * https://github.com/oat-sa/tao-core/pull/3870
* [v53.5.0](https://github.com/oat-sa/tao-core/releases/tag/v53.5.0)
  * https://github.com/oat-sa/tao-core/pull/3854
* [v53.5.1](https://github.com/oat-sa/tao-core/releases/tag/v53.5.1)
  * https://github.com/oat-sa/tao-core/pull/3860

### oat-sa/extension-tao-task-queue
* [v6.7.3](https://github.com/oat-sa/extension-tao-task-queue/releases/tag/v6.7.3)
  * https://github.com/oat-sa/extension-tao-task-queue/pull/165
* [v6.8.0](https://github.com/oat-sa/extension-tao-task-queue/releases/tag/v6.8.0)
  * https://github.com/oat-sa/extension-tao-task-queue/pull/167

[ADF-1571]: https://oat-sa.atlassian.net/browse/ADF-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ