### PR TITLE
fix: missing compiled translations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "oat-sa/extension-tao-community": "11.0.4",
     "oat-sa/extension-tao-funcacl": "7.4.0",
     "oat-sa/extension-tao-dac-simple": "7.10.5",
-    "oat-sa/extension-tao-itemqti": "30.2.0",
+    "oat-sa/extension-tao-itemqti": "30.2.3.3",
     "oat-sa/extension-tao-testqti": "47.2.0",
     "oat-sa/extension-tao-testtaker": "8.11.1",
     "oat-sa/extension-tao-group": "7.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52191d8b30966bc7b6a7ca0e9028f69b",
+    "content-hash": "69ed7f113ce3578ff354acc30fd90637",
     "packages": [
         {
             "name": "clearfw/clearfw",
@@ -3944,16 +3944,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v30.2.0",
+            "version": "v30.2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "c9889469677541eb7a777ad2788d68e33b18d11b"
+                "reference": "64450cffc32073aac82985ff531274376e3230e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/c9889469677541eb7a777ad2788d68e33b18d11b",
-                "reference": "c9889469677541eb7a777ad2788d68e33b18d11b",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/64450cffc32073aac82985ff531274376e3230e8",
+                "reference": "64450cffc32073aac82985ff531274376e3230e8",
                 "shasum": ""
             },
             "require": {
@@ -4030,9 +4030,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v30.2.0"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v30.2.3.3"
             },
-            "time": "2023-07-07T10:32:28+00:00"
+            "time": "2023-09-20T08:22:50+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
Update taoQtiItem with version `v30.2.3.3` that contains compiled translations