### PR TITLE
Hotfix/INV-707/2023.05/Broken tooltip

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     "oat-sa/extension-tao-ltideliveryprovider": "12.14.0",
     "oat-sa/extension-tao-revision": "10.6.2",
     "oat-sa/extension-tao-mediamanager": "12.34.3.2",
-    "oat-sa/extension-pcisample": "3.7.0",
+    "oat-sa/extension-pcisample": "3.7.0.0",
     "oat-sa/extension-tao-backoffice": "6.11.3",
     "oat-sa/extension-tao-proctoring": "20.6.0",
     "oat-sa/extension-tao-clientdiag": "8.4.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9d40b29e0200f262a432b88413b51b1",
+    "content-hash": "f463e05fa27bad3aeac348e3b4e71720",
     "packages": [
         {
             "name": "cebe/php-openapi",
@@ -3375,16 +3375,16 @@
         },
         {
             "name": "oat-sa/extension-pcisample",
-            "version": "v3.7.0",
+            "version": "v3.7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-pcisample.git",
-                "reference": "3593001951acab8bea51f5582cf543a71eb0c726"
+                "reference": "2c16b9bd9bf439acd4db3ca3a4349159dff3d16f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-pcisample/zipball/3593001951acab8bea51f5582cf543a71eb0c726",
-                "reference": "3593001951acab8bea51f5582cf543a71eb0c726",
+                "url": "https://api.github.com/repos/oat-sa/extension-pcisample/zipball/2c16b9bd9bf439acd4db3ca3a4349159dff3d16f",
+                "reference": "2c16b9bd9bf439acd4db3ca3a4349159dff3d16f",
                 "shasum": ""
             },
             "require": {
@@ -3419,9 +3419,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-pcisample/issues",
-                "source": "https://github.com/oat-sa/extension-pcisample/tree/v3.7.0"
+                "source": "https://github.com/oat-sa/extension-pcisample/tree/v3.7.0.0.1"
             },
-            "time": "2023-02-01T09:01:12+00:00"
+            "time": "2023-11-22T09:51:54+00:00"
         },
         {
             "name": "oat-sa/extension-tao-backoffice",
@@ -11652,5 +11652,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/INV-707

### Summary

- [extension-pcisample v3.7.0.0](https://github.com/oat-sa/extension-pcisample/releases/tag/v3.7.0.0) Restore the tooltip helper in the textReader PCI.

![image](https://github.com/oat-sa/extension-pcisample/assets/1500098/97fd53c9-3584-498f-b437-e7b925f3ccad)

### Details

- [extension-pcisample v3.7.0.0](https://github.com/oat-sa/extension-pcisample/releases/tag/v3.7.0.0) When migrating the PCI to the IMS standard, we made some surgery to remove or adapt incompatible code. However, it was a tad too aggressive, and [the helper responsible for preparing the tooltip was removed together with the one that brought MathJAX](https://github.com/oat-sa/extension-pcisample/pull/87/files#diff-82c38155dd7370921087076be131fa5e089961d18643a4bdb36253e7ad5d3470L186).

### How to test
- install TAO from tao-community v2023.05.5
- check out the branch
- update TAO
- have an item with the textReader PCI and some tooltips (you can use the ones attached to the ticket)
- publish a delivery (or pick up an existing one if any)
- take the test and check the tooltip works
