### PR TITLE
Hotfix/INV-707/2023.08/Broken tooltip

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     "oat-sa/extension-tao-ltideliveryprovider": "12.16.0",
     "oat-sa/extension-tao-revision": "10.7.1",
     "oat-sa/extension-tao-mediamanager": "12.36.0.1",
-    "oat-sa/extension-pcisample": "3.8.1",
+    "oat-sa/extension-pcisample": "3.8.1.1",
     "oat-sa/extension-tao-backoffice": "6.12.5",
     "oat-sa/extension-tao-proctoring": "20.7.1",
     "oat-sa/extension-tao-clientdiag": "8.5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af180b74783212e55ee9bdd13f8af4ee",
+    "content-hash": "1cb06f793fbca4ca292619a513f0304e",
     "packages": [
         {
             "name": "clearfw/clearfw",
@@ -3200,16 +3200,16 @@
         },
         {
             "name": "oat-sa/extension-pcisample",
-            "version": "v3.8.1",
+            "version": "v3.8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-pcisample.git",
-                "reference": "0a888692d1d401a0bbb1e7b6ec581776a581302c"
+                "reference": "3907a72cf1f15db411d1700b0ce1bdc918cc35c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-pcisample/zipball/0a888692d1d401a0bbb1e7b6ec581776a581302c",
-                "reference": "0a888692d1d401a0bbb1e7b6ec581776a581302c",
+                "url": "https://api.github.com/repos/oat-sa/extension-pcisample/zipball/3907a72cf1f15db411d1700b0ce1bdc918cc35c2",
+                "reference": "3907a72cf1f15db411d1700b0ce1bdc918cc35c2",
                 "shasum": ""
             },
             "require": {
@@ -3244,9 +3244,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-pcisample/issues",
-                "source": "https://github.com/oat-sa/extension-pcisample/tree/v3.8.1"
+                "source": "https://github.com/oat-sa/extension-pcisample/tree/v3.8.1.1"
             },
-            "time": "2023-06-02T15:10:47+00:00"
+            "time": "2023-11-22T09:55:06+00:00"
         },
         {
             "name": "oat-sa/extension-tao-backoffice",
@@ -11337,5 +11337,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/INV-707

### Summary

- [extension-pcisample v3.8.1.1](https://github.com/oat-sa/extension-pcisample/releases/tag/v3.8.1.1) Restore the tooltip helper in the textReader PCI.

![image](https://github.com/oat-sa/extension-pcisample/assets/1500098/97fd53c9-3584-498f-b437-e7b925f3ccad)

### Details

- [extension-pcisample v3.8.1.1](https://github.com/oat-sa/extension-pcisample/releases/tag/v3.8.1.1) When migrating the PCI to the IMS standard, we made some surgery to remove or adapt incompatible code. However, it was a tad too aggressive, and [the helper responsible for preparing the tooltip was removed together with the one that brought MathJAX](https://github.com/oat-sa/extension-pcisample/pull/87/files#diff-82c38155dd7370921087076be131fa5e089961d18643a4bdb36253e7ad5d3470L186).

### How to test
- install TAO from tao-community v2023.08.5
- check out the branch
- update TAO
- have an item with the textReader PCI and some tooltips (you can use the ones attached to the ticket)
- publish a delivery (or pick up an existing one if any)
- take the test and check the tooltip works
