### PR TITLE
Hotfix/INV-707/2023.11/Broken tooltip

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     "oat-sa/extension-tao-ltideliveryprovider": "12.17.0",
     "oat-sa/extension-tao-revision": "10.7.2",
     "oat-sa/extension-tao-mediamanager": "12.39.0",
-    "oat-sa/extension-pcisample": "3.8.3",
+    "oat-sa/extension-pcisample": "3.8.4",
     "oat-sa/extension-tao-backoffice": "6.12.7",
     "oat-sa/extension-tao-proctoring": "20.7.3",
     "oat-sa/extension-tao-clientdiag": "8.5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4abacb05eafecbed1f144846fa786db0",
+    "content-hash": "b6c3eef2b6c934c5a2d29e4724829b6d",
     "packages": [
         {
             "name": "clearfw/clearfw",
@@ -3204,16 +3204,16 @@
         },
         {
             "name": "oat-sa/extension-pcisample",
-            "version": "v3.8.3",
+            "version": "v3.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-pcisample.git",
-                "reference": "5cd8af8ed708e877b03c35c432af9c3afa1eb222"
+                "reference": "ca87425f232675c1c2feab468603e5d844bd73c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-pcisample/zipball/5cd8af8ed708e877b03c35c432af9c3afa1eb222",
-                "reference": "5cd8af8ed708e877b03c35c432af9c3afa1eb222",
+                "url": "https://api.github.com/repos/oat-sa/extension-pcisample/zipball/ca87425f232675c1c2feab468603e5d844bd73c3",
+                "reference": "ca87425f232675c1c2feab468603e5d844bd73c3",
                 "shasum": ""
             },
             "require": {
@@ -3249,9 +3249,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-pcisample/issues",
-                "source": "https://github.com/oat-sa/extension-pcisample/tree/v3.8.3"
+                "source": "https://github.com/oat-sa/extension-pcisample/tree/v3.8.4"
             },
-            "time": "2023-09-08T11:57:17+00:00"
+            "time": "2023-11-10T12:49:52+00:00"
         },
         {
             "name": "oat-sa/extension-tao-backoffice",
@@ -11389,5 +11389,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/INV-707

### Summary

- [extension-pcisample v3.8.4](https://github.com/oat-sa/extension-pcisample/releases/tag/v3.8.4) Restore the tooltip helper in the textReader PCI.

![image](https://github.com/oat-sa/extension-pcisample/assets/1500098/97fd53c9-3584-498f-b437-e7b925f3ccad)

### Details

- [extension-pcisample v3.8.4](https://github.com/oat-sa/extension-pcisample/releases/tag/v3.8.4) When migrating the PCI to the IMS standard, we made some surgery to remove or adapt incompatible code. However, it was a tad too aggressive, and [the helper responsible for preparing the tooltip was removed together with the one that brought MathJAX](https://github.com/oat-sa/extension-pcisample/pull/87/files#diff-82c38155dd7370921087076be131fa5e089961d18643a4bdb36253e7ad5d3470L186).

### How to test
- install TAO from tao-community v2023.11.3
- check out the branch
- update TAO
- have an item with the textReader PCI and some tooltips (you can use the ones attached to the ticket)
- publish a delivery (or pick up an existing one if any)
- take the test and check the tooltip works
