### PR TITLE
chore: backport - enforce default value for testtaker import

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "oat-sa/extension-tao-dac-simple": "8.0.1",
     "oat-sa/extension-tao-itemqti": "30.4.1",
     "oat-sa/extension-tao-testqti": "48.1.1",
-    "oat-sa/extension-tao-testtaker": "8.11.2",
+    "oat-sa/extension-tao-testtaker": "8.12.0",
     "oat-sa/extension-tao-group": "7.8.2",
     "oat-sa/extension-tao-item": "12.1.2",
     "oat-sa/extension-tao-itemqti-pci": "8.12.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9aef69355eabc7e89e545fdafd71adc2",
+    "content-hash": "803cab976979b058316b068e040dd805",
     "packages": [
         {
             "name": "clearfw/clearfw",
@@ -5374,16 +5374,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testtaker",
-            "version": "v8.11.2",
+            "version": "v8.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testtaker.git",
-                "reference": "44530b3b793f4fe48514fa70bfffd304fc9dc72f"
+                "reference": "e908d1290583ea4174e25f6afd2264a48dff01da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testtaker/zipball/44530b3b793f4fe48514fa70bfffd304fc9dc72f",
-                "reference": "44530b3b793f4fe48514fa70bfffd304fc9dc72f",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testtaker/zipball/e908d1290583ea4174e25f6afd2264a48dff01da",
+                "reference": "e908d1290583ea4174e25f6afd2264a48dff01da",
                 "shasum": ""
             },
             "require": {
@@ -5449,9 +5449,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testtaker/tree/v8.11.2"
+                "source": "https://github.com/oat-sa/extension-tao-testtaker/tree/v8.12.0"
             },
-            "time": "2023-08-18T11:03:24+00:00"
+            "time": "2024-01-17T17:17:33+00:00"
         },
         {
             "name": "oat-sa/generis",


### PR DESCRIPTION
Backport for: https://github.com/oat-sa/extension-tao-testtaker/pull/239

Changelog:
* `oat-sa/extension-tao-testtaker` version bumped