### PR TITLE
chore: update 2024.06 release with RFE-1271

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "prefer-stable": true,
   "require": {
     "oat-sa/generis": "15.36.0",
-    "oat-sa/tao-core": "54.13.0",
+    "oat-sa/tao-core": "54.13.1",
     "oat-sa/extension-tao-community": "11.1.3",
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "286c0248b5c983635496b744794b3886",
+    "content-hash": "a9e909f9fc0d7ea2580307e4b76cd228",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -6165,16 +6165,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v54.13.0",
+            "version": "v54.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "0ef7725729421914c16d081c93e4a957f3439e6c"
+                "reference": "a62407e00bf525f1a62b68e6ea126325207d98af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/0ef7725729421914c16d081c93e4a957f3439e6c",
-                "reference": "0ef7725729421914c16d081c93e4a957f3439e6c",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/a62407e00bf525f1a62b68e6ea126325207d98af",
+                "reference": "a62407e00bf525f1a62b68e6ea126325207d98af",
                 "shasum": ""
             },
             "require": {
@@ -6275,9 +6275,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v54.13.0"
+                "source": "https://github.com/oat-sa/tao-core/tree/v54.13.1"
             },
-            "time": "2024-05-14T15:20:11+00:00"
+            "time": "2024-05-17T14:35:09+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -12183,5 +12183,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Update oat-sa/tao-core to [54.13.1 ](https://github.com/oat-sa/tao-core/releases/tag/v54.13.1)