### PR TITLE
Feature/RFE-1147/Apply the Solar Design

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "prefer-stable": true,
   "require": {
     "oat-sa/generis": "15.36.0",
-    "oat-sa/tao-core": "54.13.1",
+    "oat-sa/tao-core": "54.14.0",
     "oat-sa/extension-tao-community": "11.1.3",
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "oat-sa/extension-tao-community": "11.1.3",
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",
-    "oat-sa/extension-tao-itemqti": "30.10.6",
+    "oat-sa/extension-tao-itemqti": "30.11.0",
     "oat-sa/extension-tao-testqti": "48.5.1",
     "oat-sa/extension-tao-testtaker": "8.12.3",
     "oat-sa/extension-tao-group": "7.9.0",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",
     "oat-sa/extension-tao-itemqti": "30.11.0",
-    "oat-sa/extension-tao-testqti": "48.5.1",
+    "oat-sa/extension-tao-testqti": "48.6.0",
     "oat-sa/extension-tao-testtaker": "8.12.3",
     "oat-sa/extension-tao-group": "7.9.0",
     "oat-sa/extension-tao-item": "12.2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d647349cc2c465a3cbc89a92a1357441",
+    "content-hash": "988b384fffb83c5adfc573a1c94f1da7",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -6165,16 +6165,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v54.13.1",
+            "version": "v54.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "a62407e00bf525f1a62b68e6ea126325207d98af"
+                "reference": "4692836dca69dfa3ed616e30071ab037984183e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/a62407e00bf525f1a62b68e6ea126325207d98af",
-                "reference": "a62407e00bf525f1a62b68e6ea126325207d98af",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/4692836dca69dfa3ed616e30071ab037984183e2",
+                "reference": "4692836dca69dfa3ed616e30071ab037984183e2",
                 "shasum": ""
             },
             "require": {
@@ -6275,9 +6275,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v54.13.1"
+                "source": "https://github.com/oat-sa/tao-core/tree/v54.14.0"
             },
-            "time": "2024-05-17T14:35:09+00:00"
+            "time": "2024-05-28T09:19:37+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9729cf8807ed76203b99af95e1421f6f",
+    "content-hash": "119ceface4693a446729cf3bf370f4cd",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -5291,16 +5291,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti",
-            "version": "v48.5.1",
+            "version": "v48.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "4ee46178e679c98769b898b6034eae271060a7d8"
+                "reference": "74d7a79a1550e7484818425f5171c41c887e9d65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/4ee46178e679c98769b898b6034eae271060a7d8",
-                "reference": "4ee46178e679c98769b898b6034eae271060a7d8",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/74d7a79a1550e7484818425f5171c41c887e9d65",
+                "reference": "74d7a79a1550e7484818425f5171c41c887e9d65",
                 "shasum": ""
             },
             "require": {
@@ -5315,7 +5315,7 @@
                 "oat-sa/generis": ">=15.22",
                 "oat-sa/lib-test-cat": "2.3.7",
                 "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-                "oat-sa/tao-core": ">=54.0.0",
+                "oat-sa/tao-core": ">=54.14.0",
                 "qtism/qtism": ">=0.28.3",
                 "slim/slim": "^3.0"
             },
@@ -5384,9 +5384,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v48.5.1"
+                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v48.6.0"
             },
-            "time": "2024-05-17T15:38:22+00:00"
+            "time": "2024-05-28T10:15:23+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "988b384fffb83c5adfc573a1c94f1da7",
+    "content-hash": "9729cf8807ed76203b99af95e1421f6f",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -4220,16 +4220,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v30.10.6",
+            "version": "v30.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "f430fa850c5ebdd251e5ffa893081bf8376a57e0"
+                "reference": "3a1e17fd1b9b50d6139b4a852bf1573ba79c64dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/f430fa850c5ebdd251e5ffa893081bf8376a57e0",
-                "reference": "f430fa850c5ebdd251e5ffa893081bf8376a57e0",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/3a1e17fd1b9b50d6139b4a852bf1573ba79c64dc",
+                "reference": "3a1e17fd1b9b50d6139b4a852bf1573ba79c64dc",
                 "shasum": ""
             },
             "require": {
@@ -4240,7 +4240,7 @@
                 "oat-sa/generis": ">=15.22",
                 "oat-sa/lib-tao-qti": "^7.8.1",
                 "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-                "oat-sa/tao-core": ">=54.0.0"
+                "oat-sa/tao-core": ">=54.14.0"
             },
             "type": "tao-extension",
             "extra": {
@@ -4306,9 +4306,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v30.10.6"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v30.11.0"
             },
-            "time": "2024-05-24T07:54:06+00:00"
+            "time": "2024-05-28T09:58:50+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/RFE-1147

### Summary

Apply the Solar Design to the backoffice.

Integration of:
- https://github.com/oat-sa/tao-core/pull/4006
- https://github.com/oat-sa/tao-core/pull/4011
- https://github.com/oat-sa/tao-core/pull/4015
- https://github.com/oat-sa/tao-core/pull/4018
- https://github.com/oat-sa/tao-core/pull/4019
- https://github.com/oat-sa/tao-core/pull/4022
- https://github.com/oat-sa/tao-core/pull/4024
- https://github.com/oat-sa/tao-core/pull/4025
- https://github.com/oat-sa/tao-core/pull/4026
- https://github.com/oat-sa/tao-core/pull/4027
- https://github.com/oat-sa/extension-tao-itemqti/pull/2505
- https://github.com/oat-sa/extension-tao-testqti/pull/2473
- https://github.com/oat-sa/tao-core-ui-fe/pull/592

![image](https://github.com/oat-sa/tao-core/assets/1500098/c02fda2b-3f5d-4ecc-8f25-e4b95eef6d03)

### Details

To activate the feature, you need the feature flag `FEATURE_FLAG_SOLAR_DESIGN_ENABLED`.
```sh
php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_SOLAR_DESIGN_ENABLED -v true
```

Once activated, the CSS class `solar-design` is added to the body element of the page. Then, the stylesheet automatically applies.

The Solar Design has been partially replicated in the CSS variables. For compatibility reasons, some have been simplified.

The backoffice is now following the Solar Design.

### How to test

- check out the branch: `git checkout -t origin/feature/RFE-1147/solar-design`
- activate the feature flag: `php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_SOLAR_DESIGN_ENABLED -v true`
- log in to TAO backoffice
- look at the pages, compare with the UX mockups
