### PR TITLE
Fix/RFE-1147/Apply the Solar Design

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "prefer-stable": true,
   "require": {
     "oat-sa/generis": "15.36.0",
-    "oat-sa/tao-core": "54.14.0",
+    "oat-sa/tao-core": "54.14.1",
     "oat-sa/extension-tao-community": "11.1.3",
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "119ceface4693a446729cf3bf370f4cd",
+    "content-hash": "2e480171ceb36f614433eb6250b4e9c0",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -6165,16 +6165,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v54.14.0",
+            "version": "v54.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "4692836dca69dfa3ed616e30071ab037984183e2"
+                "reference": "5dcdb9e0fd2523ab06c1ea2b5fd88a1028083a63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/4692836dca69dfa3ed616e30071ab037984183e2",
-                "reference": "4692836dca69dfa3ed616e30071ab037984183e2",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/5dcdb9e0fd2523ab06c1ea2b5fd88a1028083a63",
+                "reference": "5dcdb9e0fd2523ab06c1ea2b5fd88a1028083a63",
                 "shasum": ""
             },
             "require": {
@@ -6275,9 +6275,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v54.14.0"
+                "source": "https://github.com/oat-sa/tao-core/tree/v54.14.1"
             },
-            "time": "2024-05-28T09:19:37+00:00"
+            "time": "2024-05-29T09:24:38+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/RFE-1147

### Summary

Fix a blocking issue breaking any page load when a theme service does not inherit from `oat\tao\model\theme\ThemeService`.

Integration of:
- https://github.com/oat-sa/tao-core/pull/4029

### Details

To check if the Solar Design is enabled, the theme classes implement a check with respect to a feature flag. However, this check was placed in a parent class that is not inherited by all theme services.

This check is now moved to the abstract class.

### How to test
- check out the branch: `git checkout -t origin/fix/AUT-3626/feature-flag-for-solar-design`
- log in to TAO backoffice
- the page should load
- activate the feature flag: `php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_SOLAR_DESIGN_ENABLED -v true`
- check that the Solar Design applies

Note: the issue arose with the extension taoStyles which is using another theme service (PersistenceThemeService)