### PR TITLE
Fix/ADF-1664/Solar design glitches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "oat-sa/extension-tao-community": "11.1.3",
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",
-    "oat-sa/extension-tao-itemqti": "30.11.0",
+    "oat-sa/extension-tao-itemqti": "30.11.1",
     "oat-sa/extension-tao-testqti": "48.6.0",
     "oat-sa/extension-tao-testtaker": "8.12.3",
     "oat-sa/extension-tao-group": "7.9.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "prefer-stable": true,
   "require": {
     "oat-sa/generis": "15.36.0",
-    "oat-sa/tao-core": "54.14.1",
+    "oat-sa/tao-core": "54.14.2",
     "oat-sa/extension-tao-community": "11.1.3",
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4be72be8361f25eba736e618b27b9a2",
+    "content-hash": "9d6c14dd16e2a4744278262a862a308b",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -4220,16 +4220,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v30.11.0",
+            "version": "v30.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "3a1e17fd1b9b50d6139b4a852bf1573ba79c64dc"
+                "reference": "c2554dce626a74b1c7f3b04a884cc588b5c3e2ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/3a1e17fd1b9b50d6139b4a852bf1573ba79c64dc",
-                "reference": "3a1e17fd1b9b50d6139b4a852bf1573ba79c64dc",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/c2554dce626a74b1c7f3b04a884cc588b5c3e2ec",
+                "reference": "c2554dce626a74b1c7f3b04a884cc588b5c3e2ec",
                 "shasum": ""
             },
             "require": {
@@ -4306,9 +4306,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v30.11.0"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v30.11.1"
             },
-            "time": "2024-05-28T09:58:50+00:00"
+            "time": "2024-05-31T13:27:46+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e480171ceb36f614433eb6250b4e9c0",
+    "content-hash": "e4be72be8361f25eba736e618b27b9a2",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -6165,16 +6165,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v54.14.1",
+            "version": "v54.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "5dcdb9e0fd2523ab06c1ea2b5fd88a1028083a63"
+                "reference": "1685032d5ef9652821e9f6ebc87e0da75b2ffa64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/5dcdb9e0fd2523ab06c1ea2b5fd88a1028083a63",
-                "reference": "5dcdb9e0fd2523ab06c1ea2b5fd88a1028083a63",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/1685032d5ef9652821e9f6ebc87e0da75b2ffa64",
+                "reference": "1685032d5ef9652821e9f6ebc87e0da75b2ffa64",
                 "shasum": ""
             },
             "require": {
@@ -6275,9 +6275,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v54.14.1"
+                "source": "https://github.com/oat-sa/tao-core/tree/v54.14.2"
             },
-            "time": "2024-05-29T09:24:38+00:00"
+            "time": "2024-05-31T13:16:55+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1664

### Summary

Fix a few UI glitches in the backoffice when the Solar Design applies and a custom theme is already in place.

Integration of:
- https://github.com/oat-sa/tao-core/pull/4031
- https://github.com/oat-sa/extension-tao-itemqti/pull/2509


### Details

Enforce some style to replace custom theme even when `!important` has been used.

Note: the issues arose especially with the extension taoStyles when a theme variant is applied.

### How to test

- check out the branch: `git checkout -t origin/fix/ADF-1664/solar-design-glitches`
- activate the feature flag: `php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_SOLAR_DESIGN_ENABLED -v true`
- log in to TAO backoffice
- look at the pages, compare with the UX mockups