### PR TITLE
chore: backport for RFE-1283 into June release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "oat-sa/extension-tao-itemqti-pic": "7.0.7",
     "oat-sa/extension-tao-test": "16.1.4",
     "oat-sa/extension-tao-outcome": "13.8.1",
-    "oat-sa/extension-tao-outcomeui": "12.3.0",
+    "oat-sa/extension-tao-outcomeui": "12.3.1",
     "oat-sa/extension-tao-outcomerds": "8.4.3",
     "oat-sa/extension-tao-outcomekeyvalue": "6.2.2",
     "oat-sa/extension-tao-outcomelti": "5.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "deba770ae827023e48f4a8152f2fac78",
+    "content-hash": "f757cbcfef8e7d9f14368c94cf51b825",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -4943,16 +4943,16 @@
         },
         {
             "name": "oat-sa/extension-tao-outcomeui",
-            "version": "v12.3.0",
+            "version": "v12.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-outcomeui.git",
-                "reference": "17d7a115b53fe10283655a600f8a0427ff3befb4"
+                "reference": "e46e873805fb8b6b3b3c8cf7f3d246877a7d4750"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-outcomeui/zipball/17d7a115b53fe10283655a600f8a0427ff3befb4",
-                "reference": "17d7a115b53fe10283655a600f8a0427ff3befb4",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-outcomeui/zipball/e46e873805fb8b6b3b3c8cf7f3d246877a7d4750",
+                "reference": "e46e873805fb8b6b3b3c8cf7f3d246877a7d4750",
                 "shasum": ""
             },
             "require": {
@@ -5024,9 +5024,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-outcomeui/tree/v12.3.0"
+                "source": "https://github.com/oat-sa/extension-tao-outcomeui/tree/v12.3.1"
             },
-            "time": "2024-02-01T18:12:33+00:00"
+            "time": "2024-05-30T09:35:12+00:00"
         },
         {
             "name": "oat-sa/extension-tao-proctoring",


### PR DESCRIPTION
Backport for https://oat-sa.atlassian.net/browse/RFE-1283
The changes are: https://github.com/oat-sa/extension-tao-outcomeui/pull/492/files