### PR TITLE
release: update tao-core to 54.14.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "prefer-stable": true,
   "require": {
     "oat-sa/generis": "15.36.1",
-    "oat-sa/tao-core": "54.14.2",
+    "oat-sa/tao-core": "54.14.3",
     "oat-sa/extension-tao-community": "11.1.3",
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ea360d22d038fcfcef3f1132e10a232",
+    "content-hash": "d5c6f9b5a67cda596486cd473e5421e2",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -6165,16 +6165,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v54.14.2",
+            "version": "v54.14.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "1685032d5ef9652821e9f6ebc87e0da75b2ffa64"
+                "reference": "ab6c2c9f66abf63e618b7d8ac8aade4d0c778fe2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/1685032d5ef9652821e9f6ebc87e0da75b2ffa64",
-                "reference": "1685032d5ef9652821e9f6ebc87e0da75b2ffa64",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/ab6c2c9f66abf63e618b7d8ac8aade4d0c778fe2",
+                "reference": "ab6c2c9f66abf63e618b7d8ac8aade4d0c778fe2",
                 "shasum": ""
             },
             "require": {
@@ -6275,9 +6275,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v54.14.2"
+                "source": "https://github.com/oat-sa/tao-core/tree/v54.14.3"
             },
-            "time": "2024-05-31T13:16:55+00:00"
+            "time": "2024-06-07T10:36:58+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1664

### Summary

Update tao-core to version [54.14.3](https://github.com/oat-sa/tao-core/releases/tag/v54.14.3).

### Details

Fix another set of UI glitches in the backoffice when the Solar Design applies and a custom theme is already in place.
A few places were not following well the design:
- the tab selector when publishing a test (select local or remote)
- the buttons inside the item form (workflow buttons)
- the bottom bar for the look & feel (nice to have, but this would be hidden in the end)

The action bars in the lists and remote lists were hidden as they were considered empty.

### How to test

- check out the branch: `git checkout -t origin/fix/ADF-1664/solar-design-glitches-part2`
- activate the feature flag: `php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_SOLAR_DESIGN_ENABLED -v true`
- log in to TAO backoffice
- look at the pages, compare with the UX mockups