### PR TITLE
fix: backport import metadata checkbox fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "oat-sa/extension-tao-community": "11.1.3",
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",
-    "oat-sa/extension-tao-itemqti": "30.20.0",
+    "oat-sa/extension-tao-itemqti": "30.20.0.1",
     "oat-sa/extension-tao-testqti": "48.10.0",
     "oat-sa/extension-tao-testtaker": "8.12.3",
     "oat-sa/extension-tao-group": "7.9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c9829bc8092001a08fe1e0a91dcc5c5",
+    "content-hash": "8c0f702d69f8ce5569becc640b72314f",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -4214,16 +4214,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v30.20.0",
+            "version": "30.20.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "c04cdbd30c74027374833c6a88fe8c3b15a01585"
+                "reference": "481403823879b137211d723055a44e050f1a12a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/c04cdbd30c74027374833c6a88fe8c3b15a01585",
-                "reference": "c04cdbd30c74027374833c6a88fe8c3b15a01585",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/481403823879b137211d723055a44e050f1a12a3",
+                "reference": "481403823879b137211d723055a44e050f1a12a3",
                 "shasum": ""
             },
             "require": {
@@ -4300,9 +4300,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v30.20.0"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/30.20.0.1"
             },
-            "time": "2024-08-02T14:44:31+00:00"
+            "time": "2024-09-12T09:30:07+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
This will fix issue where user does not check QTI metadata as properties but metadata property is still imported and may fail when property does not exist.

Backport: https://github.com/oat-sa/extension-tao-itemqti/pull/2573