### PR TITLE
Release 2024.09.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",
     "oat-sa/extension-tao-itemqti": "30.20.0.1",
-    "oat-sa/extension-tao-testqti": "48.10.0",
+    "oat-sa/extension-tao-testqti": "48.10.1",
     "oat-sa/extension-tao-testtaker": "8.12.3",
     "oat-sa/extension-tao-group": "7.9.0",
     "oat-sa/extension-tao-item": "12.3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c0f702d69f8ce5569becc640b72314f",
+    "content-hash": "c524645c926d6e98ca74c2dd33ce70b0",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -5285,16 +5285,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti",
-            "version": "v48.10.0",
+            "version": "v48.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "03c4aba9316b5792e79761bf29dab60bd4a17d3a"
+                "reference": "b8855c4627c5bffc06d762825bfea65dbec59f13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/03c4aba9316b5792e79761bf29dab60bd4a17d3a",
-                "reference": "03c4aba9316b5792e79761bf29dab60bd4a17d3a",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/b8855c4627c5bffc06d762825bfea65dbec59f13",
+                "reference": "b8855c4627c5bffc06d762825bfea65dbec59f13",
                 "shasum": ""
             },
             "require": {
@@ -5378,9 +5378,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v48.10.0"
+                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v48.10.1"
             },
-            "time": "2024-07-31T14:50:40+00:00"
+            "time": "2024-10-02T07:02:39+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",


### PR DESCRIPTION
oat-sa/extension-tao-testqti - 48.10.1 - fix importing QTI Packages without metadata