### PR TITLE
Stabilisation 2024.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",
     "oat-sa/extension-tao-itemqti": "30.21.1",
-    "oat-sa/extension-tao-testqti": "48.12.3",
+    "oat-sa/extension-tao-testqti": "48.12.5",
     "oat-sa/extension-tao-testtaker": "8.12.3",
     "oat-sa/extension-tao-group": "7.9.0",
     "oat-sa/extension-tao-item": "12.3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "001b6d16944c0685475b3a9ec2d9d2a9",
+    "content-hash": "85e8d4fd928e601bd60574545994c044",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -5300,16 +5300,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti",
-            "version": "v48.12.3",
+            "version": "v48.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "eb97437069218c257e52b699604579e917cae93e"
+                "reference": "501996d17a90969d977f3e1cd78b979edc05db23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/eb97437069218c257e52b699604579e917cae93e",
-                "reference": "eb97437069218c257e52b699604579e917cae93e",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/501996d17a90969d977f3e1cd78b979edc05db23",
+                "reference": "501996d17a90969d977f3e1cd78b979edc05db23",
                 "shasum": ""
             },
             "require": {
@@ -5393,9 +5393,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v48.12.3"
+                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v48.12.5"
             },
-            "time": "2024-09-05T09:10:40+00:00"
+            "time": "2024-10-02T07:02:52+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",


### PR DESCRIPTION
oat-sa/extension-tao-testqti - 48.12.5 - fix importing QTI Packages without metadata