### PR TITLE
chore: backport for LSI-4788

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "oat-sa/extension-tao-clientdiag": "8.5.7",
     "oat-sa/extension-tao-eventlog": "3.5.1",
     "oat-sa/extension-tao-task-queue": "6.9.0",
-    "oat-sa/extension-tao-testqti-previewer": "3.10.2",
+    "oat-sa/extension-tao-testqti-previewer": "3.10.4",
     "oat-sa/lib-generis-search": "2.3.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c524645c926d6e98ca74c2dd33ce70b0",
+    "content-hash": "03a66dd327fc021f187c7e14d3540f53",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -5384,16 +5384,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
-            "version": "v3.10.2",
+            "version": "v3.10.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti-previewer.git",
-                "reference": "44d2b00429bdc28b1a21f6c12953cbc0fe246bf4"
+                "reference": "68342c271e39844e29c14cd254f413a29b92ddda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/44d2b00429bdc28b1a21f6c12953cbc0fe246bf4",
-                "reference": "44d2b00429bdc28b1a21f6c12953cbc0fe246bf4",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti-previewer/zipball/68342c271e39844e29c14cd254f413a29b92ddda",
+                "reference": "68342c271e39844e29c14cd254f413a29b92ddda",
                 "shasum": ""
             },
             "require": {
@@ -5402,7 +5402,7 @@
                 "oat-sa/extension-tao-itemqti": ">=28.22.0",
                 "oat-sa/extension-tao-outcome": ">=13.0.0",
                 "oat-sa/extension-tao-test": ">=15.0.0",
-                "oat-sa/extension-tao-testqti": ">=47.2.3",
+                "oat-sa/extension-tao-testqti": ">=47.3.0",
                 "oat-sa/generis": ">=15.22",
                 "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
                 "oat-sa/tao-core": ">=54.0.0",
@@ -5438,9 +5438,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.10.2"
+                "source": "https://github.com/oat-sa/extension-tao-testqti-previewer/tree/v3.10.4"
             },
-            "time": "2024-02-01T18:57:53+00:00"
+            "time": "2024-10-09T11:16:01+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testtaker",


### PR DESCRIPTION
Backport for `oat-sa/extension-tao-testqti-previewer` version
Ticket: [LSI-4788](https://oat-sa.atlassian.net/browse/LSI-4788)

[LSI-4788]: https://oat-sa.atlassian.net/browse/LSI-4788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ