### PR TITLE
Fix/LSI-5044/2024.10/runtime error in diagnostic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "oat-sa/extension-pcisample": "3.9.0",
     "oat-sa/extension-tao-backoffice": "6.13.3",
     "oat-sa/extension-tao-proctoring": "20.7.7",
-    "oat-sa/extension-tao-clientdiag": "8.5.7",
+    "oat-sa/extension-tao-clientdiag": "8.5.8",
     "oat-sa/extension-tao-eventlog": "3.5.1",
     "oat-sa/extension-tao-task-queue": "6.9.0",
     "oat-sa/extension-tao-testqti-previewer": "3.10.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f50bf666fc4196953c3b59c84ba9292",
+    "content-hash": "75207b459e25f0918e9a993ca6e0792d",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -3587,16 +3587,16 @@
         },
         {
             "name": "oat-sa/extension-tao-clientdiag",
-            "version": "v8.5.7",
+            "version": "v8.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-clientdiag.git",
-                "reference": "78600344e25f4208a15191fe14adae24baadc03e"
+                "reference": "5ebb7c4dd8ca2f8d7cf497672fd5ab6da56eaa61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-clientdiag/zipball/78600344e25f4208a15191fe14adae24baadc03e",
-                "reference": "78600344e25f4208a15191fe14adae24baadc03e",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-clientdiag/zipball/5ebb7c4dd8ca2f8d7cf497672fd5ab6da56eaa61",
+                "reference": "5ebb7c4dd8ca2f8d7cf497672fd5ab6da56eaa61",
                 "shasum": ""
             },
             "require": {
@@ -3632,9 +3632,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-tao-clientdiag/issues",
-                "source": "https://github.com/oat-sa/extension-tao-clientdiag/tree/v8.5.7"
+                "source": "https://github.com/oat-sa/extension-tao-clientdiag/tree/v8.5.8"
             },
-            "time": "2024-05-24T10:30:22+00:00"
+            "time": "2024-11-08T08:19:43+00:00"
         },
         {
             "name": "oat-sa/extension-tao-community",
@@ -12207,11 +12207,11 @@
         }
     ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/LSI-5044

### Summary

Add [extension-tao-clientdiag#340](https://github.com/oat-sa/extension-tao-clientdiag/pull/340) to the release 2024.10. It fixes a runtime issue occurring when launching a diagnostic and preventing the tool from completing the tests.
