### PR TITLE
chore: remove php 7.4 from continuous-integration.yaml

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '8.0', '8.3' ]
+        php-version: [ '8.1', '8.3' ]
         include:
           - php-version: '8.3'
             node-version: '18'

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '7.4', '8.0', '8.3' ]
+        php-version: [ '8.0', '8.3' ]
         include:
           - php-version: '8.3'
             node-version: '18'


### PR DESCRIPTION
# Goal 

Remove the PHP 7.4 check as it is not supported anymore