### PR TITLE
fix: update oat-sa/extension-tao-itemqti to 30.25.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "oat-sa/extension-tao-community": "11.1.3",
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.0.5",
-    "oat-sa/extension-tao-itemqti": "30.25.0",
+    "oat-sa/extension-tao-itemqti": "30.25.2",
     "oat-sa/extension-tao-testqti": "48.16.2",
     "oat-sa/extension-tao-testtaker": "8.12.3",
     "oat-sa/extension-tao-group": "7.9.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e53dd57b308c82c68a7a6abf251e210d",
+    "content-hash": "eabfb4fe67894594bb7d1d2a61c5388c",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -4601,16 +4601,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v30.25.0",
+            "version": "v30.25.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "4b635eb2459ac165a88d87393838c08687d50afd"
+                "reference": "34b94314d8eb2bfce62499214ae57ff5c2eaa50a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/4b635eb2459ac165a88d87393838c08687d50afd",
-                "reference": "4b635eb2459ac165a88d87393838c08687d50afd",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/34b94314d8eb2bfce62499214ae57ff5c2eaa50a",
+                "reference": "34b94314d8eb2bfce62499214ae57ff5c2eaa50a",
                 "shasum": ""
             },
             "require": {
@@ -4687,9 +4687,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v30.25.0"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v30.25.2"
             },
-            "time": "2024-12-06T09:23:20+00:00"
+            "time": "2024-12-11T10:14:11+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1389

Deploy AUT-1389 in 2025-01 release.
Update oat-sa/extension-tao-itemqti to 30.25.2