### PR TITLE
fix: backport ruby tags into RC

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "prefer-stable": true,
   "require": {
     "oat-sa/generis": "16.0.2",
-    "oat-sa/tao-core": "54.29.2",
+    "oat-sa/tao-core": "54.29.4",
     "oat-sa/extension-tao-community": "11.1.3",
     "oat-sa/extension-tao-funcacl": "7.4.6",
     "oat-sa/extension-tao-dac-simple": "8.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f4c815992fd4b613553081ef913df13",
+    "content-hash": "86423dadf93b7316dfa0c7995b699c6b",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -6547,16 +6547,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v54.29.2",
+            "version": "v54.29.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "c422eeee6698dc0f752e5e110c836f09e14f7888"
+                "reference": "bcfe9c05f0ea4b706a00a61cf275c261df045dac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/c422eeee6698dc0f752e5e110c836f09e14f7888",
-                "reference": "c422eeee6698dc0f752e5e110c836f09e14f7888",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/bcfe9c05f0ea4b706a00a61cf275c261df045dac",
+                "reference": "bcfe9c05f0ea4b706a00a61cf275c261df045dac",
                 "shasum": ""
             },
             "require": {
@@ -6657,9 +6657,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v54.29.2"
+                "source": "https://github.com/oat-sa/tao-core/tree/v54.29.4"
             },
-            "time": "2025-01-17T11:51:34+00:00"
+            "time": "2025-01-21T15:57:19+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",


### PR DESCRIPTION
Backport of https://oat-sa.atlassian.net/browse/INF-279 into February RC