### PR TITLE
chore: update extensions versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "oat-sa/extension-tao-itemqti-pci": "8.16.5",
     "oat-sa/extension-tao-itemqti-pic": "7.0.7",
     "oat-sa/extension-tao-test": "16.4.8",
-    "oat-sa/extension-tao-outcome": "13.8.3",
+    "oat-sa/extension-tao-outcome": "13.8.4",
     "oat-sa/extension-tao-outcomeui": "12.3.1",
     "oat-sa/extension-tao-outcomerds": "8.4.3",
     "oat-sa/extension-tao-outcomekeyvalue": "6.2.2",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "oat-sa/extension-tao-testqti": "48.20.6",
     "oat-sa/extension-tao-testtaker": "8.13.0",
     "oat-sa/extension-tao-group": "7.10.1",
-    "oat-sa/extension-tao-item": "12.8.0",
+    "oat-sa/extension-tao-item": "12.8.3",
     "oat-sa/extension-tao-itemqti-pci": "8.16.5",
     "oat-sa/extension-tao-itemqti-pic": "7.0.7",
     "oat-sa/extension-tao-test": "16.4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89784e0e4cdf862a866bd15a0bc92103",
+    "content-hash": "c279337d21417db7bc6e7156de8a9922",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -4509,16 +4509,16 @@
         },
         {
             "name": "oat-sa/extension-tao-item",
-            "version": "v12.8.0",
+            "version": "v12.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-item.git",
-                "reference": "2ae05b8b44ae03087cd71d9663f5a5a702036508"
+                "reference": "2d17b23af3dab09650491c2f36938c31cbf3f704"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-item/zipball/2ae05b8b44ae03087cd71d9663f5a5a702036508",
-                "reference": "2ae05b8b44ae03087cd71d9663f5a5a702036508",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-item/zipball/2d17b23af3dab09650491c2f36938c31cbf3f704",
+                "reference": "2d17b23af3dab09650491c2f36938c31cbf3f704",
                 "shasum": ""
             },
             "require": {
@@ -4593,9 +4593,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-item/tree/v12.8.0"
+                "source": "https://github.com/oat-sa/extension-tao-item/tree/v12.8.3"
             },
-            "time": "2025-04-04T13:24:09+00:00"
+            "time": "2025-05-13T08:29:55+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
@@ -5019,23 +5019,23 @@
         },
         {
             "name": "oat-sa/extension-tao-outcome",
-            "version": "v13.8.3",
+            "version": "v13.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-outcome.git",
-                "reference": "56e94905dc0b92165544c1b23bae513e9ea1dd7f"
+                "reference": "6472d8e1fdd8706cb51048fa63a4d473c6792404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-outcome/zipball/56e94905dc0b92165544c1b23bae513e9ea1dd7f",
-                "reference": "56e94905dc0b92165544c1b23bae513e9ea1dd7f",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-outcome/zipball/6472d8e1fdd8706cb51048fa63a4d473c6792404",
+                "reference": "6472d8e1fdd8706cb51048fa63a4d473c6792404",
                 "shasum": ""
             },
             "require": {
-                "oat-sa/generis": ">=15.22",
+                "oat-sa/generis": ">=16.0.0",
                 "oat-sa/lib-tao-dtms": "^1.0.1",
                 "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-                "oat-sa/tao-core": ">=50.24.6",
+                "oat-sa/tao-core": ">=54.26.0",
                 "qtism/qtism": ">=0.25.0"
             },
             "require-dev": {
@@ -5101,9 +5101,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-outcome/tree/v13.8.3"
+                "source": "https://github.com/oat-sa/extension-tao-outcome/tree/v13.8.4"
             },
-            "time": "2024-11-08T11:54:21+00:00"
+            "time": "2025-04-17T19:34:01+00:00"
         },
         {
             "name": "oat-sa/extension-tao-outcomekeyvalue",


### PR DESCRIPTION
Release 2025.05.1
Update `extension-tao-item` and `extension-tao-outcome` version