### PR TITLE
Release 2025 07

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "oat-sa/extension-tao-community": "11.1.4",
     "oat-sa/extension-tao-funcacl": "7.4.7",
     "oat-sa/extension-tao-dac-simple": "8.1.2",
-    "oat-sa/extension-tao-itemqti": "30.38.12",
+    "oat-sa/extension-tao-itemqti": "30.38.13",
     "oat-sa/extension-tao-testqti": "48.20.8",
     "oat-sa/extension-tao-testtaker": "8.13.1",
     "oat-sa/extension-tao-group": "7.10.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b5d0959f6f10b347817bb02c03f570a",
+    "content-hash": "a32ede47df8be151e890e0786c5e52c6",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -4603,16 +4603,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v30.38.12",
+            "version": "v30.38.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "915de7c6c4f8aebd51057d3912c3e84fbed1c39d"
+                "reference": "42ec6db1ad1a11140821be31725f616316910403"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/915de7c6c4f8aebd51057d3912c3e84fbed1c39d",
-                "reference": "915de7c6c4f8aebd51057d3912c3e84fbed1c39d",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/42ec6db1ad1a11140821be31725f616316910403",
+                "reference": "42ec6db1ad1a11140821be31725f616316910403",
                 "shasum": ""
             },
             "require": {
@@ -4689,9 +4689,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v30.38.12"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v30.38.13"
             },
-            "time": "2025-06-11T15:15:51+00:00"
+            "time": "2025-06-12T08:18:14+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",
@@ -12810,13 +12810,13 @@
         }
     ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Release 2025-07

Updated Packages

- generis
- tao-core
- extension-tao-itemqti
- extension-tao-testqti

🚀 New Features

**tao-core**

ADF-1977 – Added user, cookie policy, and tenant info to the config endpoint
🔗 https://github.com/oat-sa/tao-core/pull/4255
🎫 https://oat-sa.atlassian.net/browse/ADF-1977

**generis**

ADF-1977 – Added ability to read tenant ID from session
🔗 https://github.com/oat-sa/generis/pull/1152
🎫 https://oat-sa.atlassian.net/browse/ADF-1977

🛠 Fixes

**tao-core**

AUT-4221 – Restored install-tao and updated resources
🔗 https://github.com/oat-sa/tao-core/pull/4253
🎫 https://oat-sa.atlassian.net/browse/AUT-4221

TR-6452 – Vertical item layout improvements
👤 by olga-kulish
🔗 https://github.com/oat-sa/tao-core/pull/4244
🎫 https://oat-sa.atlassian.net/browse/TR-6452

**extension-tao-itemqti**

AUT-4223 – Fixed QTI 2.2 exporter
🔗 https://github.com/oat-sa/extension-tao-itemqti/pull/2749
🎫 https://oat-sa.atlassian.net/browse/AUT-4223

HKD-510 – Prevented editing of unique QTI ID
🔗 https://github.com/oat-sa/extension-tao-itemqti/pull/2744
🎫 https://oat-sa.atlassian.net/browse/HKD-510

TR-6452 – Vertical item layout improvements
👤 by olga-kulish
🔗 https://github.com/oat-sa/extension-tao-itemqti/pull/2739
🎫 https://oat-sa.atlassian.net/browse/TR-6452

TR-6577 – Fixed vertical writing number handling
🔗 https://github.com/oat-sa/extension-tao-itemqti/pull/2755
🎫 https://oat-sa.atlassian.net/browse/TR-6577

TR-6458 – Safari fix for vertical extendedText items
🔗 https://github.com/oat-sa/extension-tao-itemqti/pull/2689
🎫 https://oat-sa.atlassian.net/browse/TR-6458

**extension-tao-testqti**

HKD-510 – Prevented editing of unique QTI ID
🔗 https://github.com/oat-sa/extension-tao-testqti/pull/2612
🎫 https://oat-sa.atlassian.net/browse/HKD-510

TR-6452 – Vertical item layout improvements
👤 by olga-kulish
🔗 https://github.com/oat-sa/extension-tao-testqti/pull/2600
🎫 https://oat-sa.atlassian.net/browse/TR-6452

🔁 Backports

**tao-core**

INF-339 – Fixed updated_at timestamp update logic
🔗 https://github.com/oat-sa/tao-core/pull/4260
🎫 https://oat-sa.atlassian.net/browse/INF-339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to newer versions.
  * Changed a project keyword from "2025.06" to "2025.07".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->