### PR TITLE
Update taoQtiTest to v48.20.16.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "oat-sa/extension-tao-funcacl": "7.4.7",
     "oat-sa/extension-tao-dac-simple": "8.1.2",
     "oat-sa/extension-tao-itemqti": "30.44.0",
-    "oat-sa/extension-tao-testqti": "48.20.16",
+    "oat-sa/extension-tao-testqti": "48.20.16.1",
     "oat-sa/extension-tao-testtaker": "8.13.1",
     "oat-sa/extension-tao-group": "7.10.2",
     "oat-sa/extension-tao-item": "12.8.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4336c2b2a029f5bb31daf20967acc6fc",
+    "content-hash": "38140c6d79897cf5c119ce360e0a8f66",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -5674,16 +5674,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti",
-            "version": "v48.20.16",
+            "version": "v48.20.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "39f57529b0a6770f0586140fbeed7d41d5c16715"
+                "reference": "b94a64a84e997ec9976656f6061ee53a269a095e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/39f57529b0a6770f0586140fbeed7d41d5c16715",
-                "reference": "39f57529b0a6770f0586140fbeed7d41d5c16715",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/b94a64a84e997ec9976656f6061ee53a269a095e",
+                "reference": "b94a64a84e997ec9976656f6061ee53a269a095e",
                 "shasum": ""
             },
             "require": {
@@ -5767,9 +5767,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v48.20.16"
+                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v48.20.16.1"
             },
-            "time": "2025-07-25T14:06:00+00:00"
+            "time": "2025-08-14T15:14:38+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",


### PR DESCRIPTION
## Summary

Updates `oat-sa/extension-tao-testqti` from version `48.20.16` to `48.20.16.1`.

## Changes
- Updated composer.json to use taoQtiTest v48.20.16.1
- Updated composer.lock with new dependency version

## Context
This update incorporates the scoring grade mode visibility fix that was backported to taoQtiTest v48.20.16.1.

**Related taoQtiTest release:** https://github.com/oat-sa/extension-tao-testqti/releases/tag/v48.20.16.1