### PR TITLE
fix: HKD-1620 backport for 2026.04

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "oat-sa/extension-tao-funcacl": "7.4.10",
     "oat-sa/extension-tao-dac-simple": "10.0.0",
     "oat-sa/extension-tao-itemqti": "32.3.1",
-    "oat-sa/extension-tao-testqti": "50.1.4",
+    "oat-sa/extension-tao-testqti": "50.1.5",
     "oat-sa/extension-tao-testtaker": "8.13.5",
     "oat-sa/extension-tao-group": "7.10.3",
     "oat-sa/extension-tao-item": "13.0.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1a45bbd31f556a7e4306933f560a460",
+    "content-hash": "8ee484fd6b4511100da249b763b1a544",
     "packages": [
         {
             "name": "brick/math",
@@ -5786,16 +5786,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti",
-            "version": "v50.1.4",
+            "version": "v50.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "a51b6b77af27f29ac1eedb139af745e1242503a9"
+                "reference": "c33a430fe9424e373209cc1f2d22229328a361e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/a51b6b77af27f29ac1eedb139af745e1242503a9",
-                "reference": "a51b6b77af27f29ac1eedb139af745e1242503a9",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/c33a430fe9424e373209cc1f2d22229328a361e3",
+                "reference": "c33a430fe9424e373209cc1f2d22229328a361e3",
                 "shasum": ""
             },
             "require": {
@@ -5879,9 +5879,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v50.1.4"
+                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v50.1.5"
             },
-            "time": "2026-03-17T13:56:40+00:00"
+            "time": "2026-04-02T08:36:03+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
@@ -13202,5 +13202,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Backport HKD-1620: bump extension-tao-testqti to 50.1.5.