### PR TITLE
fix: HKD-1620 bump extension-tao-testqti to 49.2.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "oat-sa/extension-tao-funcacl": "7.4.10",
     "oat-sa/extension-tao-dac-simple": "9.0.1",
     "oat-sa/extension-tao-itemqti": "31.6.6",
-    "oat-sa/extension-tao-testqti": "49.2.8",
+    "oat-sa/extension-tao-testqti": "49.2.9",
     "oat-sa/extension-tao-testtaker": "8.13.5",
     "oat-sa/extension-tao-group": "7.10.3",
     "oat-sa/extension-tao-item": "13.0.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a0c22ab7efed6d3e38fe6f92f8bef6e",
+    "content-hash": "6b7765552877595bad42950879f85a1c",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -5696,16 +5696,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti",
-            "version": "v49.2.8",
+            "version": "v49.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "fca0d5111efc200723c89a8d3c628271e825389b"
+                "reference": "df21adf543cead0c5188423c4aebf753075d1d65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/fca0d5111efc200723c89a8d3c628271e825389b",
-                "reference": "fca0d5111efc200723c89a8d3c628271e825389b",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/df21adf543cead0c5188423c4aebf753075d1d65",
+                "reference": "df21adf543cead0c5188423c4aebf753075d1d65",
                 "shasum": ""
             },
             "require": {
@@ -5789,9 +5789,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v49.2.8"
+                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v49.2.9"
             },
-            "time": "2026-03-06T13:58:52+00:00"
+            "time": "2026-04-02T08:35:54+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
@@ -12925,5 +12925,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary
- backport HKD-1620 to release/2026.03.3
- bump `oat-sa/extension-tao-testqti` from `49.2.8` to `49.2.9` in `composer.json`