### PR TITLE
fix: HKD-1620 bump extension-tao-testqti to 49.0.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "oat-sa/extension-tao-funcacl": "7.4.10",
     "oat-sa/extension-tao-dac-simple": "9.0.1",
     "oat-sa/extension-tao-itemqti": "31.0.10",
-    "oat-sa/extension-tao-testqti": "49.0.9",
+    "oat-sa/extension-tao-testqti": "49.0.10",
     "oat-sa/extension-tao-testtaker": "8.13.5",
     "oat-sa/extension-tao-group": "7.10.3",
     "oat-sa/extension-tao-item": "13.0.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5edcd247ebf4bbb26085e2d08fd811d",
+    "content-hash": "b54b2531b184771fd32c5206e7f41181",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -5696,16 +5696,16 @@
         },
         {
             "name": "oat-sa/extension-tao-testqti",
-            "version": "v49.0.9",
+            "version": "v49.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "c4f6247e7c571ee7dcc0c62d9109a383342458b1"
+                "reference": "3495fa97a86bc6d1c1257264e88fa0aec3451462"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/c4f6247e7c571ee7dcc0c62d9109a383342458b1",
-                "reference": "c4f6247e7c571ee7dcc0c62d9109a383342458b1",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/3495fa97a86bc6d1c1257264e88fa0aec3451462",
+                "reference": "3495fa97a86bc6d1c1257264e88fa0aec3451462",
                 "shasum": ""
             },
             "require": {
@@ -5789,9 +5789,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v49.0.9"
+                "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v49.0.10"
             },
-            "time": "2026-03-11T11:00:01+00:00"
+            "time": "2026-04-02T08:34:46+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
@@ -12925,5 +12925,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary
- backport HKD-1620 to release/2026.02.13
- bump `oat-sa/extension-tao-testqti` from `49.0.9` to `49.0.10` in `composer.json`