### PR TITLE
fix(INF-489): update oat-sa/tao-core to 55.0.1.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "prefer-stable": true,
   "require": {
     "oat-sa/generis": "16.2.4",
-    "oat-sa/tao-core": "55.0.1.7",
+    "oat-sa/tao-core": "55.0.1.8",
     "oat-sa/extension-tao-community": "11.1.7",
     "oat-sa/extension-tao-funcacl": "7.4.10",
     "oat-sa/extension-tao-dac-simple": "9.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16e6ad922bb54a1ea2d6924c65b6283b",
+    "content-hash": "e2723ef4791cd91be6f9de034fd43f5d",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -5700,12 +5700,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-testqti.git",
-                "reference": "3495fa97a86bc6d1c1257264e88fa0aec3451462"
+                "reference": "9d3ddbe70e39c6bb29bc59c5eeae2214d588b84c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/3495fa97a86bc6d1c1257264e88fa0aec3451462",
-                "reference": "3495fa97a86bc6d1c1257264e88fa0aec3451462",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-testqti/zipball/9d3ddbe70e39c6bb29bc59c5eeae2214d588b84c",
+                "reference": "9d3ddbe70e39c6bb29bc59c5eeae2214d588b84c",
                 "shasum": ""
             },
             "require": {
@@ -5791,7 +5791,7 @@
                 "issues": "http://forge.taotesting.com",
                 "source": "https://github.com/oat-sa/extension-tao-testqti/tree/v49.0.10"
             },
-            "time": "2026-04-02T08:34:46+00:00"
+            "time": "2026-04-03T07:45:09+00:00"
         },
         {
             "name": "oat-sa/extension-tao-testqti-previewer",
@@ -6571,16 +6571,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v55.0.1.7",
+            "version": "v55.0.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "6ef5fbe781f775d9aaec3c2dc197fa42a869eb93"
+                "reference": "1c87fdb933b78be5eecf657c0ea6c1ec61ee2198"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/6ef5fbe781f775d9aaec3c2dc197fa42a869eb93",
-                "reference": "6ef5fbe781f775d9aaec3c2dc197fa42a869eb93",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/1c87fdb933b78be5eecf657c0ea6c1ec61ee2198",
+                "reference": "1c87fdb933b78be5eecf657c0ea6c1ec61ee2198",
                 "shasum": ""
             },
             "require": {
@@ -6681,9 +6681,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v55.0.1.7"
+                "source": "https://github.com/oat-sa/tao-core/tree/v55.0.1.8"
             },
-            "time": "2026-03-20T15:33:35+00:00"
+            "time": "2026-04-01T06:04:52+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -12925,5 +12925,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Ticket 
https://oat-sa.atlassian.net/browse/INF-489

## Summary
- bump oat-sa/tao-core to 55.0.1.8
- keep the fix isolated from the release branch baseline

## Validation
- tested in local TAO Community instance running in NGS runtime
- composer install updated oat-sa/tao-core to v55.0.1.8
- taoUpdate.php completed successfully

## Video

https://github.com/user-attachments/assets/0d1dc585-5920-4796-90c0-00cc4a28a843

