### PR TITLE
fix: update oat-sa/extension-tao-itemqti to v32.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "oat-sa/extension-tao-community": "11.1.7",
     "oat-sa/extension-tao-funcacl": "7.4.10",
     "oat-sa/extension-tao-dac-simple": "10.0.0",
-    "oat-sa/extension-tao-itemqti": "32.4.2",
+    "oat-sa/extension-tao-itemqti": "32.4.3",
     "oat-sa/extension-tao-testqti": "50.1.6",
     "oat-sa/extension-tao-testtaker": "8.13.5",
     "oat-sa/extension-tao-group": "7.10.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0bf2ebf2525fdb5caac7162dcf8efbab",
+    "content-hash": "d4d199cb8c1e25e676a3c45aa9ee0224",
     "packages": [
         {
             "name": "brick/math",
@@ -4714,16 +4714,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v32.4.2",
+            "version": "v32.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "a4e00156bae673c2e78c6e45b5c38d5e795f92c4"
+                "reference": "6e1fbb93e636c291497aca1f23a5a122ffd23789"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/a4e00156bae673c2e78c6e45b5c38d5e795f92c4",
-                "reference": "a4e00156bae673c2e78c6e45b5c38d5e795f92c4",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/6e1fbb93e636c291497aca1f23a5a122ffd23789",
+                "reference": "6e1fbb93e636c291497aca1f23a5a122ffd23789",
                 "shasum": ""
             },
             "require": {
@@ -4801,9 +4801,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v32.4.2"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v32.4.3"
             },
-            "time": "2026-04-29T15:51:48+00:00"
+            "time": "2026-05-22T09:53:52+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
backport of https://oat-sa.atlassian.net/browse/AUT-4566 to April release