### PR TITLE
chore: backport oat-sa/extension-pcisample to release-2026-08-lts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "oat-sa/extension-tao-ltideliveryprovider": "14.0.1",
     "oat-sa/extension-tao-revision": "11.0.3",
     "oat-sa/extension-tao-mediamanager": "14.1.2",
-    "oat-sa/extension-pcisample": "3.9.8",
+    "oat-sa/extension-pcisample": "3.9.9",
     "oat-sa/extension-tao-backoffice": "7.1.6",
     "oat-sa/extension-tao-proctoring": "21.0.4",
     "oat-sa/extension-tao-clientdiag": "9.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd19cfc327592c1169f7ff72f899729c",
+    "content-hash": "850ea203872bd80c4b10553fc945d481",
     "packages": [
         {
             "name": "brick/math",
@@ -4067,16 +4067,16 @@
         },
         {
             "name": "oat-sa/extension-pcisample",
-            "version": "v3.9.8",
+            "version": "v3.9.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-pcisample.git",
-                "reference": "65c40ce0d59f4f95a48f1959df4c4f952932d364"
+                "reference": "a9777b3e1e8339a72c4aac1c55949c1f8fc42803"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-pcisample/zipball/65c40ce0d59f4f95a48f1959df4c4f952932d364",
-                "reference": "65c40ce0d59f4f95a48f1959df4c4f952932d364",
+                "url": "https://api.github.com/repos/oat-sa/extension-pcisample/zipball/a9777b3e1e8339a72c4aac1c55949c1f8fc42803",
+                "reference": "a9777b3e1e8339a72c4aac1c55949c1f8fc42803",
                 "shasum": ""
             },
             "require": {
@@ -4112,9 +4112,9 @@
             ],
             "support": {
                 "issues": "https://github.com/oat-sa/extension-pcisample/issues",
-                "source": "https://github.com/oat-sa/extension-pcisample/tree/v3.9.8"
+                "source": "https://github.com/oat-sa/extension-pcisample/tree/v3.9.9"
             },
-            "time": "2026-07-03T15:01:44+00:00"
+            "time": "2026-08-05T14:02:32+00:00"
         },
         {
             "name": "oat-sa/extension-tao-backoffice",


### PR DESCRIPTION
## Summary
- Backport of `oat-sa/extension-pcisample` (`3.9.8` → `3.9.9`) into `release-2026-08-lts`.

## Why
- https://oat-sa.atlassian.net/browse/INF-565

## Test plan
- [ ] Confirm composer constraints resolve as expected
- [ ] Smoke-check Text Reader page/nav labels with ruby markup