### PR TITLE
feat(release): add tao-community release workflow

### DIFF
--- a/.github/workflows/release-tao-community.yml
+++ b/.github/workflows/release-tao-community.yml
@@ -1,5 +1,7 @@
 name: Release tao-community
 
+run-name: Release tao-community (${{ inputs.coordinator_correlation_id || format('manual-{0}', github.run_id) }})
+
 on:
   workflow_dispatch:
     inputs:
@@ -9,8 +11,9 @@ on:
         type: choice
         options: [stable, rc, lts, backport]
       source_ref:
-        description: Source branch or ref
-        required: true
+        description: Source branch
+        required: false
+        default: develop
         type: string
       release_version:
         description: Application release version
@@ -18,6 +21,10 @@ on:
         type: string
       package_manifest_run_id:
         description: ci-pipelines run containing release-package-manifest
+        required: false
+        type: string
+      coordinator_correlation_id:
+        description: Correlation ID supplied by ci-pipelines
         required: false
         type: string
       allow_stable_fallback:
@@ -56,6 +63,7 @@ jobs:
       SOURCE_REF: ${{ inputs.source_ref }}
       RELEASE_VERSION: ${{ inputs.release_version }}
       MANIFEST_RUN_ID: ${{ inputs.package_manifest_run_id }}
+      COORDINATOR_CORRELATION_ID: ${{ inputs.coordinator_correlation_id || format('manual-{0}', github.run_id) }}
       ALLOW_STABLE_FALLBACK: ${{ inputs.allow_stable_fallback }}
       ALLOW_LTS_FALLBACK: ${{ inputs.allow_lts_fallback }}
       BACKPORT_PACKAGE: ${{ inputs.backport_package }}
@@ -73,6 +81,8 @@ jobs:
             --release_type "$RELEASE_TYPE" \
             --source_ref "$SOURCE_REF" \
             --release_version "$RELEASE_VERSION" \
+            --package_manifest_run_id "$MANIFEST_RUN_ID" \
+            --coordinator_correlation_id "$COORDINATOR_CORRELATION_ID" \
             --allow_stable_fallback "$ALLOW_STABLE_FALLBACK" \
             --allow_lts_fallback "$ALLOW_LTS_FALLBACK" \
             --backport_package "$BACKPORT_PACKAGE" \
@@ -97,20 +107,29 @@ jobs:
           branch="release-$RELEASE_VERSION"
           tag="release-$RELEASE_VERSION"
           pr_url=""
-          release_url=""
-          manifest_path=""
+           release_url=""
+           manifest_path=""
+           mkdir -p .release-input
+           printf '{"release_type":"%s","source_ref":"%s","package_results":[]}' "$RELEASE_TYPE" "$SOURCE_REF" > .release-input/release-package-manifest.json
+           manifest_artifact=.release-input/release-package-manifest.json
 
           if [ "${{ steps.contract.outcome }}" != success ]; then
             status=failure
             failure_reason="normalized release contract validation failed"
           fi
-           if [ "$status" = success ]; then
-             git fetch --no-tags origin "$SOURCE_REF" || { status=failure; failure_reason="source ref could not be fetched"; }
-             git ls-remote --exit-code --heads origin "$SOURCE_REF" >/dev/null 2>&1 || { status=failure; failure_reason="source ref must be an existing branch"; }
-           fi
+            source_sha=""
+            if [ "$status" = success ]; then
+              git fetch --no-tags origin "$SOURCE_REF" || { status=failure; failure_reason="source ref could not be fetched"; }
+              git ls-remote --exit-code --heads origin "$SOURCE_REF" >/dev/null 2>&1 || { status=failure; failure_reason="source ref must be an existing branch"; }
+              source_sha="$(git rev-parse "origin/$SOURCE_REF")" || { status=failure; failure_reason="source ref SHA could not be resolved"; }
+            fi
            if [ "$status" = success ]; then
              if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-               git fetch --no-tags origin "$branch" && git switch -C "$branch" "origin/$branch" || { status=failure; failure_reason="existing release branch could not be reused"; }
+                git fetch --no-tags origin "$branch" && git switch -C "$branch" "origin/$branch" || { status=failure; failure_reason="existing release branch could not be reused"; }
+                if [ "$status" = success ] && [ "$(git merge-base HEAD "origin/$SOURCE_REF")" != "$source_sha" ]; then
+                  status=failure
+                  failure_reason="existing release branch has an incompatible source base SHA"
+                fi
              else
                git switch -C "$branch" "origin/$SOURCE_REF" || { status=failure; failure_reason="release branch could not be prepared"; }
              fi
@@ -239,16 +258,43 @@ jobs:
                package_release_url="https://github.com/$package_repo/releases/tag/$package_tag"
                package_run_url="https://github.com/$package_repo/actions/runs/$package_run_id"
                mkdir -p .release-input
-               jq -n --arg package "$BACKPORT_PACKAGE" --arg repository "$package_repo" --arg tag "$package_tag" --arg version "$backport_version" --arg commit "$package_commit" --arg release_url "$package_release_url" --arg workflow_run_url "$package_run_url" '{package:$package,repository:$repository,tag:$tag,version:$version,commit:$commit,release_url:$release_url,workflow_run_url:$workflow_run_url}' > .release-input/backport-package.json
-               manifest_path=.release-input/backport-package.json
+                jq -n --arg package "$BACKPORT_PACKAGE" --arg repository "$package_repo" --arg tag "$package_tag" --arg version "$backport_version" --arg commit "$package_commit" --arg release_url "$package_release_url" --arg workflow_run_url "$package_run_url" '{release_type:"backport",package_results:[{package:$package,repository:$repository,tag:$tag,version:$version,commit:$commit,release_url:$release_url,workflow_run_url:$workflow_run_url}]}' > "$manifest_artifact"
+                manifest_path="$manifest_artifact"
              fi
            fi
 
-           if [ "$status" = success ] && [ -n "$MANIFEST_RUN_ID" ]; then
+            if [ "$status" = success ] && [ -z "$MANIFEST_RUN_ID" ] && [ -z "$manifest_path" ]; then
+             mkdir -p .release-input
+             jq -r '.require | keys[]' composer.json | while IFS= read -r package; do
+                repository="$(jq -r --arg package "$package" '((.packages // []) + (."packages-dev" // []))[] | select(.name == $package) | .source.url' composer.lock | sed -E -e 's#^https://github.com/([^/]+/[^/]+)(\.git)?$#\1#' -e 's#^git@github.com:([^/]+/[^/]+)(\.git)?$#\1#' | head -n 1)"
+                [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || { echo "Could not resolve repository for $package" >&2; exit 1; }
+                gh api --paginate "repos/$repository/branches?per_page=100" > ".release-input/$(printf '%s' "$package" | tr '/' '_')-branches.json" || exit 1
+               gh api --paginate "repos/$repository/tags?per_page=100" > ".release-input/$(printf '%s' "$package" | tr '/' '_')-tags.json" || exit 1
+                workflow_url="$(gh run list --repo "$repository" --workflow release_tao_extension.yml --limit 1 --json url --jq '.[0].url // ""' | tr -d '\n')" || exit 1
+                [[ -n "$workflow_url" ]] || { echo "No extension workflow run found for $package" >&2; exit 1; }
+                printf '%s' "$workflow_url" > ".release-input/$(printf '%s' "$package" | tr '/' '_')-workflow-url"
+             done || { status=failure; failure_reason="target-local package release data could not be read"; }
+             if [ "$status" = success ]; then
+               jq -n --slurpfile composer composer.json --arg release_type "$RELEASE_TYPE" --arg source_ref "$SOURCE_REF" \
+                 '{release_type:$release_type,source_ref:$source_ref,packages:($composer[0].require | keys | map({key:.,value:{repository:.}}) | from_entries)}' > .release-input/package-catalog.json
+               while IFS= read -r package; do
+                 safe_package="$(printf '%s' "$package" | tr '/' '_')"
+                 jq --arg package "$package" --slurpfile branches ".release-input/$safe_package-branches.json" --slurpfile tags ".release-input/$safe_package-tags.json" \
+                   --rawfile workflow_url ".release-input/$safe_package-workflow-url" \
+                   '.packages[$package].branches=($branches[0] | map({name:.name,commit:.commit.sha})) | .packages[$package].tags=($tags[0] | map({name:.name,commit:.commit.sha})) | .packages[$package].workflow_run_url=$workflow_url' \
+                   .release-input/package-catalog.json > .release-input/package-catalog.tmp && mv .release-input/package-catalog.tmp .release-input/package-catalog.json
+               done < <(jq -r '.require | keys[]' composer.json)
+               php scripts/release-community.php resolve --composer composer.json --catalog .release-input/package-catalog.json --release_type "$RELEASE_TYPE" --source_ref "$SOURCE_REF" --release_version "$RELEASE_VERSION" --allow_stable_fallback "$ALLOW_STABLE_FALLBACK" --allow_lts_fallback "$ALLOW_LTS_FALLBACK" --output "$manifest_artifact" || { status=failure; failure_reason="target-local package resolution failed"; }
+               manifest_path="$manifest_artifact"
+             fi
+           fi
+
+            if [ "$status" = success ] && [ -n "$MANIFEST_RUN_ID" ]; then
             mkdir -p .release-input
-            gh run download "$MANIFEST_RUN_ID" --repo oat-sa/ci-pipelines --name release-package-manifest --dir .release-input || { status=failure; failure_reason="package manifest could not be downloaded"; }
-            manifest_path="$(find .release-input -type f -name '*.json' -print -quit)"
-            [ -n "$manifest_path" ] || { status=failure; failure_reason="package manifest JSON is missing"; }
+             gh run download "$MANIFEST_RUN_ID" --repo oat-sa/ci-pipelines --name release-package-manifest --dir .release-input/external || { status=failure; failure_reason="package manifest could not be downloaded"; }
+             external_manifest="$(find .release-input/external -type f -name 'release-package-manifest.json' -print -quit)"
+             [ -n "$external_manifest" ] || { status=failure; failure_reason="package manifest JSON is missing"; }
+             if [ "$status" = success ]; then cp "$external_manifest" "$manifest_artifact"; manifest_path="$manifest_artifact"; fi
           fi
 
            if [ "$status" = success ] && [ -n "$manifest_path" ]; then
@@ -266,6 +312,7 @@ jobs:
             fi
             if [ "$status" = success ]; then
               composer validate --no-check-publish || { status=failure; failure_reason="Composer validation failed"; }
+              php scripts/release-community.php lock-validate --lock composer.lock --manifest "$manifest_path" || { status=failure; failure_reason="Composer lock does not match package results"; }
                php scripts/release-community.php scope \
                  --before .composer-before.json \
                  --after composer.json \
@@ -314,7 +361,8 @@ jobs:
             --output release-result.json \
             --release_type "$RELEASE_TYPE" \
             --source_ref "$SOURCE_REF" \
-            --release_version "$RELEASE_VERSION" \
+             --release_version "$RELEASE_VERSION" \
+             --coordinator_correlation_id "$COORDINATOR_CORRELATION_ID" \
             --status "$status" \
             --branch "$branch" \
             --pull_request_url "$pr_url" \
@@ -332,6 +380,14 @@ jobs:
         with:
           name: release-result
           path: release-result.json
+          if-no-files-found: error
+
+      - name: Publish release-package-manifest artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-package-manifest
+          path: .release-input/release-package-manifest.json
           if-no-files-found: error
 
       - name: Add workflow summary

--- a/.github/workflows/release-tao-community.yml
+++ b/.github/workflows/release-tao-community.yml
@@ -1,0 +1,318 @@
+name: Release tao-community
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Release mode
+        required: true
+        type: choice
+        options: [stable, rc, lts, backport]
+      source_ref:
+        description: Source branch or ref
+        required: true
+        type: string
+      release_version:
+        description: Application release version
+        required: true
+        type: string
+      package_manifest_run_id:
+        description: ci-pipelines run containing release-package-manifest
+        required: false
+        type: string
+      allow_stable_fallback:
+        description: Allow stable package fallback
+        required: true
+        default: false
+        type: boolean
+      allow_lts_fallback:
+        description: Allow LTS package fallback
+        required: true
+        default: false
+        type: boolean
+      backport_package:
+        description: Package to backport
+        required: false
+        type: string
+      backport_source_pr:
+        description: Source package PR URL or number
+        required: false
+        type: string
+      backport_target_branch:
+        description: Target package release branch
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN || github.token }}
+      RELEASE_TYPE: ${{ inputs.release_type }}
+      SOURCE_REF: ${{ inputs.source_ref }}
+      RELEASE_VERSION: ${{ inputs.release_version }}
+      MANIFEST_RUN_ID: ${{ inputs.package_manifest_run_id }}
+      ALLOW_STABLE_FALLBACK: ${{ inputs.allow_stable_fallback }}
+      ALLOW_LTS_FALLBACK: ${{ inputs.allow_lts_fallback }}
+      BACKPORT_PACKAGE: ${{ inputs.backport_package }}
+      BACKPORT_SOURCE_PR: ${{ inputs.backport_source_pr }}
+      BACKPORT_TARGET_BRANCH: ${{ inputs.backport_target_branch }}
+    steps:
+      - name: Checkout workflow code
+        uses: actions/checkout@v4
+
+      - name: Validate normalized release contract
+        id: contract
+        continue-on-error: true
+        run: |
+          php scripts/release-community.php validate \
+            --release_type "$RELEASE_TYPE" \
+            --source_ref "$SOURCE_REF" \
+            --release_version "$RELEASE_VERSION" \
+            --allow_stable_fallback "$ALLOW_STABLE_FALLBACK" \
+            --allow_lts_fallback "$ALLOW_LTS_FALLBACK" \
+            --backport_package "$BACKPORT_PACKAGE" \
+            --backport_source_pr "$BACKPORT_SOURCE_PR" \
+            --backport_target_branch "$BACKPORT_TARGET_BRANCH"
+
+      - name: Set up PHP and Composer
+        if: always()
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Run release orchestration
+        id: orchestration
+        if: always()
+        continue-on-error: true
+        run: |
+          set +e
+          status=success
+          failure_reason=""
+          branch="release-$RELEASE_VERSION"
+          tag="release-$RELEASE_VERSION"
+          pr_url=""
+          release_url=""
+          manifest_path=""
+
+          if [ "${{ steps.contract.outcome }}" != success ]; then
+            status=failure
+            failure_reason="normalized release contract validation failed"
+          fi
+          if [ "$status" = success ]; then
+            git fetch --no-tags origin "$SOURCE_REF" || { status=failure; failure_reason="source ref could not be fetched"; }
+          fi
+           if [ "$status" = success ]; then
+             if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+               git fetch --no-tags origin "$branch" && git switch -C "$branch" "origin/$branch" || { status=failure; failure_reason="existing release branch could not be reused"; }
+             else
+               git switch -C "$branch" "origin/$SOURCE_REF" || { status=failure; failure_reason="release branch could not be prepared"; }
+             fi
+           fi
+
+           if [ "$status" = success ] && [ "$RELEASE_TYPE" = backport ]; then
+             case "$BACKPORT_PACKAGE" in
+               [a-z0-9_.-]*/[a-z0-9_.-]*) ;;
+               *) status=failure; failure_reason="invalid backport package" ;;
+             esac
+             if [ "$status" = success ]; then
+               php scripts/backport-release.php repository --lock composer.lock --package "$BACKPORT_PACKAGE" --output .backport-repository || { status=failure; failure_reason="package repository could not be resolved"; }
+               package_repo="$(tr -d '\n' < .backport-repository)"
+               case "$package_repo" in
+                 */*) ;;
+                 *) status=failure; failure_reason="package repository could not be resolved" ;;
+               esac
+             fi
+             if [ "$status" = success ]; then
+               case "$BACKPORT_SOURCE_PR" in
+                 http://github.com/*|https://github.com/*) pr_number="${BACKPORT_SOURCE_PR##*/}" ;;
+                 [0-9]*) pr_number="$BACKPORT_SOURCE_PR" ;;
+                 *) status=failure; failure_reason="invalid source pull request" ;;
+               esac
+               case "$pr_number" in
+                 ''|*[!0-9]*) status=failure; failure_reason="invalid source pull request number" ;;
+               esac
+             fi
+             if [ "$status" = success ]; then
+               pr_metadata="$(gh api "repos/$package_repo/pulls/$pr_number" --jq '[.base.repo.full_name, (.merged_at // "")] | @tsv')" || { status=failure; failure_reason="source pull request could not be read"; }
+               source_repo="${pr_metadata%%$'\t'*}"
+               merged_at="${pr_metadata#*$'\t'}"
+               if [ "$source_repo" != "$package_repo" ]; then status=failure; failure_reason="source pull request repository does not own the package"; fi
+               if [ -z "$merged_at" ]; then status=failure; failure_reason="source pull request is not merged"; fi
+             fi
+             if [ "$status" = success ]; then
+               current_version="$(php -r '$c=json_decode(file_get_contents("composer.json"), true); echo $c["require"][getenv("BACKPORT_PACKAGE")] ?? "";' )"
+               [ -n "$current_version" ] || { status=failure; failure_reason="backport package is not a direct requirement"; }
+             fi
+             if [ "$status" = success ]; then
+               gh api --paginate "repos/$package_repo/tags" --jq '.[].name' | jq -Rsc 'split("\n") | map(select(length > 0))' > .backport-tags.json || { status=failure; failure_reason="package tags could not be read"; }
+               php scripts/backport-release.php allocate --current "$current_version" --tags .backport-tags.json --output .backport-version || { status=failure; failure_reason="backport version could not be allocated"; }
+               backport_version="$(tr -d '\n' < .backport-version)"
+               backport_branch="release-$backport_version"
+             fi
+             if [ "$status" = success ]; then
+               rm -rf .backport-package
+               gh repo clone "$package_repo" .backport-package -- --no-tags || { status=failure; failure_reason="package repository could not be cloned"; }
+             fi
+             if [ "$status" = success ]; then
+               git -C .backport-package fetch origin "$BACKPORT_TARGET_BRANCH" || { status=failure; failure_reason="backport target branch does not exist"; }
+               git -C .backport-package fetch origin "$backport_branch" 2>/dev/null || true
+               target_sha="$(git -C .backport-package rev-parse "origin/$BACKPORT_TARGET_BRANCH")" || { status=failure; failure_reason="backport target branch does not exist"; }
+               if [ "$status" = success ] && git -C .backport-package show-ref --verify --quiet "refs/remotes/origin/$backport_branch"; then
+                 branch_sha="$(git -C .backport-package rev-parse "origin/$backport_branch")"
+                 git -C .backport-package merge-base --is-ancestor "$target_sha" "$branch_sha" || { status=failure; failure_reason="existing backport branch has an incompatible base"; }
+                 git -C .backport-package switch -C "$backport_branch" "origin/$backport_branch" || { status=failure; failure_reason="existing backport branch could not be reused"; }
+               elif [ "$status" = success ]; then
+                 git -C .backport-package switch -C "$backport_branch" "origin/$BACKPORT_TARGET_BRANCH" || { status=failure; failure_reason="backport branch could not be created"; }
+               fi
+             fi
+             if [ "$status" = success ]; then
+               gh api --paginate "repos/$package_repo/pulls/$pr_number/commits" --jq '.[].sha' > .backport-commits || { status=failure; failure_reason="source pull request commits could not be read"; }
+               while IFS= read -r commit_sha; do
+                 [ -n "$commit_sha" ] || continue
+                 git -C .backport-package cherry-pick "$commit_sha" || {
+                   if git -C .backport-package diff --quiet && git -C .backport-package diff --cached --quiet; then
+                     git -C .backport-package cherry-pick --skip || { status=failure; failure_reason="source pull request cherry-pick could not be resumed"; break; }
+                   else
+                     git -C .backport-package cherry-pick --abort || true; status=failure; failure_reason="source pull request cherry-pick conflicted"; break
+                   fi
+                 }
+               done < .backport-commits
+             fi
+             if [ "$status" = success ]; then
+               git -C .backport-package push origin "HEAD:$backport_branch" || { status=failure; failure_reason="backport branch push failed"; }
+             fi
+             if [ "$status" = success ]; then
+               dispatch_started="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+               gh workflow run release_tao_extension.yml --repo "$package_repo" --ref "$backport_branch" \
+                 -f release_branch="$backport_branch" -f release_version="$backport_version" -f build_fe=auto -f build_locale=auto -f backport=true \
+                 || { status=failure; failure_reason="extension backport workflow could not be dispatched"; }
+             fi
+             if [ "$status" = success ]; then
+               package_run_id=""
+               for attempt in $(seq 1 30); do
+                 package_run_id="$(gh run list --repo "$package_repo" --workflow release_tao_extension.yml --branch "$backport_branch" --event workflow_dispatch --limit 20 --json databaseId,createdAt | jq -r --arg started "$dispatch_started" 'first(.[] | select(.createdAt >= $started) | .databaseId) // empty')"
+                 [ -n "$package_run_id" ] && break
+                 sleep 10
+               done
+               [ -n "$package_run_id" ] || { status=failure; failure_reason="extension backport workflow run could not be identified"; }
+               if [ "$status" = success ]; then
+                 package_conclusion="$(gh run view "$package_run_id" --repo "$package_repo" --json status,conclusion --jq '.status + ":" + (.conclusion // "")')"
+                 while [ "${package_conclusion%%:*}" != completed ]; do sleep 10; package_conclusion="$(gh run view "$package_run_id" --repo "$package_repo" --json status,conclusion --jq '.status + ":" + (.conclusion // "")')"; done
+                 [ "${package_conclusion#*:}" = success ] || { status=failure; failure_reason="extension backport workflow failed"; }
+               fi
+             fi
+             if [ "$status" = success ]; then
+               package_tag="v$backport_version"
+               package_commit="$(gh api "repos/$package_repo/commits/$package_tag" --jq .sha)" || { status=failure; failure_reason="backport package tag is missing"; }
+               package_release_url="https://github.com/$package_repo/releases/tag/$package_tag"
+               package_run_url="https://github.com/$package_repo/actions/runs/$package_run_id"
+               mkdir -p .release-input
+               jq -n --arg package "$BACKPORT_PACKAGE" --arg repository "$package_repo" --arg tag "$package_tag" --arg version "$backport_version" --arg commit "$package_commit" --arg release_url "$package_release_url" --arg workflow_run_url "$package_run_url" '{package:$package,repository:$repository,tag:$tag,version:$version,commit:$commit,release_url:$release_url,workflow_run_url:$workflow_run_url}' > .release-input/backport-package.json
+               manifest_path=.release-input/backport-package.json
+             fi
+           fi
+
+           if [ "$status" = success ] && [ -n "$MANIFEST_RUN_ID" ]; then
+            mkdir -p .release-input
+            gh run download "$MANIFEST_RUN_ID" --repo oat-sa/ci-pipelines --name release-package-manifest --dir .release-input || { status=failure; failure_reason="package manifest could not be downloaded"; }
+            manifest_path="$(find .release-input -type f -name '*.json' -print -quit)"
+            [ -n "$manifest_path" ] || { status=failure; failure_reason="package manifest JSON is missing"; }
+          fi
+
+           if [ "$status" = success ] && [ -n "$manifest_path" ]; then
+            cp composer.json .composer-before.json
+            cp composer.lock .composer-lock-before.json
+            php scripts/release-community.php apply \
+              --manifest "$manifest_path" \
+              --release_type "$RELEASE_TYPE" \
+              --allow_stable_fallback "$ALLOW_STABLE_FALLBACK" \
+              --allow_lts_fallback "$ALLOW_LTS_FALLBACK" \
+              --backport_package "$BACKPORT_PACKAGE" \
+              --output .release-packages || { status=failure; failure_reason="package manifest validation failed"; }
+            if [ "$status" = success ] && [ -s .release-packages ]; then
+              xargs composer update --no-install --no-scripts < .release-packages || { status=failure; failure_reason="Composer update failed"; }
+            fi
+            if [ "$status" = success ]; then
+              composer validate --no-check-publish || { status=failure; failure_reason="Composer validation failed"; }
+               php scripts/release-community.php scope \
+                 --before .composer-before.json \
+                 --after composer.json \
+                 --release_type "$RELEASE_TYPE" \
+                 --backport_package "$BACKPORT_PACKAGE" || { status=failure; failure_reason="Composer scope validation failed"; }
+               if [ "$status" = success ] && [ "$RELEASE_TYPE" = backport ]; then
+                 php scripts/backport-release.php lock-scope --before .composer-lock-before.json --after composer.lock --package "$BACKPORT_PACKAGE" || { status=failure; failure_reason="Backport changed an unexpected Composer lock entry"; }
+               fi
+             fi
+          fi
+
+          if [ "$status" = success ] && git diff --quiet; then
+            failure_reason="release has no Composer changes"
+            status=failure
+          fi
+          if [ "$status" = success ]; then
+            git diff --check || { status=failure; failure_reason="whitespace validation failed"; }
+            git add composer.json composer.lock
+            git commit -m "chore: prepare tao-community $RELEASE_VERSION" || { status=failure; failure_reason="release commit failed"; }
+            git push origin "$branch" || { status=failure; failure_reason="release branch push failed"; }
+          fi
+          if [ "$status" = success ]; then
+            pr_url="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$branch" --base "$SOURCE_REF" --json url --jq '.[0].url' | tr -d '\n')"
+            if [ -z "$pr_url" ]; then
+              pr_url="$(gh pr create --repo "$GITHUB_REPOSITORY" --base "$SOURCE_REF" --head "$branch" --title "Release tao-community $RELEASE_VERSION" --body "Automated tao-community release preparation for $RELEASE_VERSION.")" || { status=failure; failure_reason="release PR could not be created"; }
+            fi
+          fi
+          if [ "$status" = success ]; then
+            existing_tag_sha="$(git ls-remote origin "refs/tags/$tag" | cut -f1)"
+            local_sha="$(git rev-parse HEAD)"
+            if [ -n "$existing_tag_sha" ] && [ "$existing_tag_sha" != "$local_sha" ]; then
+              status=failure
+              failure_reason="application tag already points to another commit"
+            elif [ -z "$existing_tag_sha" ]; then
+              git tag "$tag" HEAD
+              git push origin "refs/tags/$tag" || { status=failure; failure_reason="application tag could not be pushed"; }
+            fi
+            if [ "$status" = success ]; then
+              release_url="$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json url --jq .url 2>/dev/null || true)"
+              if [ -z "$release_url" ]; then
+                release_url="$(gh release create "$tag" --repo "$GITHUB_REPOSITORY" --title "tao-community $RELEASE_VERSION" --generate-notes)" || { status=failure; failure_reason="GitHub release could not be created"; }
+              fi
+            fi
+          fi
+          php scripts/release-community.php result \
+            --output release-result.json \
+            --release_type "$RELEASE_TYPE" \
+            --source_ref "$SOURCE_REF" \
+            --release_version "$RELEASE_VERSION" \
+            --status "$status" \
+            --branch "$branch" \
+            --pull_request_url "$pr_url" \
+            --tag "$tag" \
+            --release_url "$release_url" \
+            --package_manifest "$manifest_path" \
+            --failure_reason "$failure_reason"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "failure_reason=$failure_reason" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Publish release-result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-result
+          path: release-result.json
+          if-no-files-found: error
+
+      - name: Add workflow summary
+        if: always()
+        run: |
+          if [ -f release-result.json ]; then
+            printf '### tao-community release\n\n```json\n' >> "$GITHUB_STEP_SUMMARY"
+            cat release-result.json >> "$GITHUB_STEP_SUMMARY"
+            printf '\n```\n' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release-tao-community.yml
+++ b/.github/workflows/release-tao-community.yml
@@ -104,9 +104,10 @@ jobs:
             status=failure
             failure_reason="normalized release contract validation failed"
           fi
-          if [ "$status" = success ]; then
-            git fetch --no-tags origin "$SOURCE_REF" || { status=failure; failure_reason="source ref could not be fetched"; }
-          fi
+           if [ "$status" = success ]; then
+             git fetch --no-tags origin "$SOURCE_REF" || { status=failure; failure_reason="source ref could not be fetched"; }
+             git ls-remote --exit-code --heads origin "$SOURCE_REF" >/dev/null 2>&1 || { status=failure; failure_reason="source ref must be an existing branch"; }
+           fi
            if [ "$status" = success ]; then
              if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
                git fetch --no-tags origin "$branch" && git switch -C "$branch" "origin/$branch" || { status=failure; failure_reason="existing release branch could not be reused"; }
@@ -171,8 +172,11 @@ jobs:
                  git -C .backport-package switch -C "$backport_branch" "origin/$BACKPORT_TARGET_BRANCH" || { status=failure; failure_reason="backport branch could not be created"; }
                fi
              fi
-             if [ "$status" = success ]; then
-               gh api --paginate "repos/$package_repo/pulls/$pr_number/commits" --jq '.[].sha' > .backport-commits || { status=failure; failure_reason="source pull request commits could not be read"; }
+              if [ "$status" = success ]; then
+                git -C .backport-package fetch origin "refs/pull/$pr_number/head:refs/remotes/origin/pr/$pr_number" || { status=failure; failure_reason="source pull request commits could not be fetched"; }
+              fi
+              if [ "$status" = success ]; then
+                gh api --paginate "repos/$package_repo/pulls/$pr_number/commits" --jq '.[].sha' > .backport-commits || { status=failure; failure_reason="source pull request commits could not be read"; }
                while IFS= read -r commit_sha; do
                  [ -n "$commit_sha" ] || continue
                  git -C .backport-package cherry-pick "$commit_sha" || {
@@ -193,19 +197,41 @@ jobs:
                  -f release_branch="$backport_branch" -f release_version="$backport_version" -f build_fe=auto -f build_locale=auto -f backport=true \
                  || { status=failure; failure_reason="extension backport workflow could not be dispatched"; }
              fi
-             if [ "$status" = success ]; then
-               package_run_id=""
-               for attempt in $(seq 1 30); do
-                 package_run_id="$(gh run list --repo "$package_repo" --workflow release_tao_extension.yml --branch "$backport_branch" --event workflow_dispatch --limit 20 --json databaseId,createdAt | jq -r --arg started "$dispatch_started" 'first(.[] | select(.createdAt >= $started) | .databaseId) // empty')"
-                 [ -n "$package_run_id" ] && break
-                 sleep 10
-               done
-               [ -n "$package_run_id" ] || { status=failure; failure_reason="extension backport workflow run could not be identified"; }
-               if [ "$status" = success ]; then
-                 package_conclusion="$(gh run view "$package_run_id" --repo "$package_repo" --json status,conclusion --jq '.status + ":" + (.conclusion // "")')"
-                 while [ "${package_conclusion%%:*}" != completed ]; do sleep 10; package_conclusion="$(gh run view "$package_run_id" --repo "$package_repo" --json status,conclusion --jq '.status + ":" + (.conclusion // "")')"; done
-                 [ "${package_conclusion#*:}" = success ] || { status=failure; failure_reason="extension backport workflow failed"; }
-               fi
+              if [ "$status" = success ]; then
+                package_run_id=""
+                deadline=$((SECONDS + 1800))
+                for attempt in $(seq 1 30); do
+                  if ! package_run_id="$(gh run list --repo "$package_repo" --workflow release_tao_extension.yml --branch "$backport_branch" --event workflow_dispatch --limit 20 --json databaseId,createdAt | jq -r --arg started "$dispatch_started" 'first(.[] | select(.createdAt >= $started) | .databaseId) // empty')"; then
+                    status=failure
+                    failure_reason="extension backport workflow run lookup failed"
+                    break
+                  fi
+                  [ -n "$package_run_id" ] && break
+                  sleep 10
+                done
+                [ -n "$package_run_id" ] || { status=failure; failure_reason="extension backport workflow run could not be identified"; }
+                if [ "$status" = success ]; then
+                  if ! package_conclusion="$(gh run view "$package_run_id" --repo "$package_repo" --json status,conclusion --jq '.status + ":" + (.conclusion // "")')"; then
+                    status=failure
+                    failure_reason="extension backport workflow status could not be read"
+                  fi
+                  while [ "$status" = success ] && [ "${package_conclusion%%:*}" != completed ]; do
+                    if (( SECONDS >= deadline )); then
+                      status=failure
+                      failure_reason="extension backport workflow timed out"
+                      break
+                    fi
+                    sleep 10
+                    if ! package_conclusion="$(gh run view "$package_run_id" --repo "$package_repo" --json status,conclusion --jq '.status + ":" + (.conclusion // "")')"; then
+                      status=failure
+                      failure_reason="extension backport workflow status could not be read"
+                    fi
+                  done
+                  if [ "$status" = success ] && [ "${package_conclusion#*:}" != success ]; then
+                    status=failure
+                    failure_reason="extension backport workflow failed"
+                  fi
+                fi
              fi
              if [ "$status" = success ]; then
                package_tag="v$backport_version"

--- a/.github/workflows/release-tao-community.yml
+++ b/.github/workflows/release-tao-community.yml
@@ -268,20 +268,20 @@ jobs:
              jq -r '.require | keys[]' composer.json | while IFS= read -r package; do
                 repository="$(jq -r --arg package "$package" '((.packages // []) + (."packages-dev" // []))[] | select(.name == $package) | .source.url' composer.lock | sed -E -e 's#^https://github.com/([^/]+/[^/]+)(\.git)?$#\1#' -e 's#^git@github.com:([^/]+/[^/]+)(\.git)?$#\1#' | head -n 1)"
                 [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || { echo "Could not resolve repository for $package" >&2; exit 1; }
-                gh api --paginate "repos/$repository/branches?per_page=100" > ".release-input/$(printf '%s' "$package" | tr '/' '_')-branches.json" || exit 1
-               gh api --paginate "repos/$repository/tags?per_page=100" > ".release-input/$(printf '%s' "$package" | tr '/' '_')-tags.json" || exit 1
-                workflow_url="$(gh run list --repo "$repository" --workflow release_tao_extension.yml --limit 1 --json url --jq '.[0].url // ""' | tr -d '\n')" || exit 1
-                [[ -n "$workflow_url" ]] || { echo "No extension workflow run found for $package" >&2; exit 1; }
-                printf '%s' "$workflow_url" > ".release-input/$(printf '%s' "$package" | tr '/' '_')-workflow-url"
+                 gh api --paginate "repos/$repository/branches?per_page=100" --jq '.[]' | jq -s '.' > ".release-input/$(printf '%s' "$package" | tr '/' '_')-branches.json" || exit 1
+                gh api --paginate "repos/$repository/tags?per_page=100" --jq '.[]' | jq -s '.' > ".release-input/$(printf '%s' "$package" | tr '/' '_')-tags.json" || exit 1
+                 gh run list --repo "$repository" --workflow release_tao_extension.yml --limit 100 --json headSha,url,status,conclusion \
+                   --jq '[.[] | select(.status == "completed" and .conclusion == "success") | {key:.headSha,value:.url}] | from_entries' \
+                   > ".release-input/$(printf '%s' "$package" | tr '/' '_')-workflow-runs.json" || exit 1
              done || { status=failure; failure_reason="target-local package release data could not be read"; }
              if [ "$status" = success ]; then
                jq -n --slurpfile composer composer.json --arg release_type "$RELEASE_TYPE" --arg source_ref "$SOURCE_REF" \
                  '{release_type:$release_type,source_ref:$source_ref,packages:($composer[0].require | keys | map({key:.,value:{repository:.}}) | from_entries)}' > .release-input/package-catalog.json
                while IFS= read -r package; do
                  safe_package="$(printf '%s' "$package" | tr '/' '_')"
-                 jq --arg package "$package" --slurpfile branches ".release-input/$safe_package-branches.json" --slurpfile tags ".release-input/$safe_package-tags.json" \
-                   --rawfile workflow_url ".release-input/$safe_package-workflow-url" \
-                   '.packages[$package].branches=($branches[0] | map({name:.name,commit:.commit.sha})) | .packages[$package].tags=($tags[0] | map({name:.name,commit:.commit.sha})) | .packages[$package].workflow_run_url=$workflow_url' \
+                    jq --arg package "$package" --slurpfile branches ".release-input/$safe_package-branches.json" --slurpfile tags ".release-input/$safe_package-tags.json" \
+                    --slurpfile workflow_runs ".release-input/$safe_package-workflow-runs.json" \
+                    '.packages[$package].branches=($branches[0] | map({name:.name,commit:.commit.sha})) | .packages[$package].tags=($tags[0] | map({name:.name,commit:.commit.sha})) | .packages[$package].workflow_runs=$workflow_runs[0]' \
                    .release-input/package-catalog.json > .release-input/package-catalog.tmp && mv .release-input/package-catalog.tmp .release-input/package-catalog.json
                done < <(jq -r '.require | keys[]' composer.json)
                php scripts/release-community.php resolve --composer composer.json --catalog .release-input/package-catalog.json --release_type "$RELEASE_TYPE" --source_ref "$SOURCE_REF" --release_version "$RELEASE_VERSION" --allow_stable_fallback "$ALLOW_STABLE_FALLBACK" --allow_lts_fallback "$ALLOW_LTS_FALLBACK" --output "$manifest_artifact" || { status=failure; failure_reason="target-local package resolution failed"; }

--- a/scripts/backport-release.php
+++ b/scripts/backport-release.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+function releaseBackportError(string $message): void
+{
+    fwrite(STDERR, $message . PHP_EOL);
+    exit(1);
+}
+
+function releaseBackportVersion(string $version): array
+{
+    $version = ltrim($version, 'v');
+    if (!preg_match('/^\d+(?:\.\d+){2,3}$/', $version)) {
+        releaseBackportError("Unsupported package version: {$version}");
+    }
+
+    return array_map('intval', explode('.', $version));
+}
+
+function releaseBackportAllocateVersion(string $current, array $tags): string
+{
+    $parts = releaseBackportVersion($current);
+    $occupied = [];
+    foreach ($tags as $tag) {
+        if (is_string($tag) && preg_match('/^v?\d+(?:\.\d+){2,3}$/', $tag)) {
+            $occupied[implode('.', releaseBackportVersion($tag))] = true;
+        }
+    }
+
+    if (count($parts) === 4) {
+        do {
+            $parts[3]++;
+        } while (isset($occupied[implode('.', $parts)]));
+        return implode('.', $parts);
+    }
+
+    $candidate = $parts;
+    $candidate[2]++;
+    if (!isset($occupied[implode('.', $candidate)])) {
+        return implode('.', $candidate);
+    }
+
+    $suffix = 1;
+    do {
+        $candidate = array_merge($parts, [$suffix++]);
+    } while (isset($occupied[implode('.', $candidate)]));
+
+    return implode('.', $candidate);
+}
+
+function releaseBackportValidateLockScope(array $before, array $after, string $package): void
+{
+    $normalize = static function (array $lock) use ($package): array {
+        unset($lock['content-hash']);
+        foreach (['packages', 'packages-dev'] as $section) {
+            $lock[$section] = array_values(array_filter(
+                $lock[$section] ?? [],
+                static fn (array $entry): bool => ($entry['name'] ?? '') !== $package
+            ));
+        }
+        return $lock;
+    };
+    $before = $normalize($before);
+    $after = $normalize($after);
+    if ($before !== $after) {
+        releaseBackportError('Backport changed an unexpected Composer lock entry');
+    }
+}
+
+function releaseBackportRepository(array $lock, string $package): string
+{
+    foreach (['packages', 'packages-dev'] as $section) {
+        foreach (($lock[$section] ?? []) as $entry) {
+            if (($entry['name'] ?? '') !== $package) {
+                continue;
+            }
+            $url = (string) ($entry['source']['url'] ?? '');
+            if (!preg_match('~github\.com[:/]([^/]+/[^/#]+?)(?:\.git)?$~', $url, $match)) {
+                releaseBackportError("No GitHub source repository found for {$package}");
+            }
+            return $match[1];
+        }
+    }
+
+    releaseBackportError("Package is not present in composer.lock: {$package}");
+}
+
+function releaseBackportArguments(array $argv): array
+{
+    $arguments = [];
+    for ($index = 2; $index < count($argv); $index++) {
+        if (strpos($argv[$index], '--') !== 0 || !isset($argv[$index + 1])) {
+            releaseBackportError('Arguments must use --name value');
+        }
+        $arguments[substr($argv[$index], 2)] = $argv[++$index];
+    }
+    return $arguments;
+}
+
+if (($argv[1] ?? '') === 'allocate') {
+    $arguments = releaseBackportArguments($argv);
+    $tags = json_decode((string) file_get_contents($arguments['tags']), true);
+    if (!is_array($tags)) {
+        releaseBackportError('Tag list must be a JSON array');
+    }
+    file_put_contents($arguments['output'], releaseBackportAllocateVersion($arguments['current'], $tags) . PHP_EOL);
+    exit(0);
+}
+
+if (($argv[1] ?? '') === 'repository') {
+    $arguments = releaseBackportArguments($argv);
+    $lock = json_decode((string) file_get_contents($arguments['lock']), true);
+    if (!is_array($lock)) {
+        releaseBackportError('Invalid composer.lock');
+    }
+    file_put_contents($arguments['output'], releaseBackportRepository($lock, $arguments['package']) . PHP_EOL);
+    exit(0);
+}
+
+if (($argv[1] ?? '') === 'lock-scope') {
+    $arguments = releaseBackportArguments($argv);
+    $before = json_decode((string) file_get_contents($arguments['before']), true);
+    $after = json_decode((string) file_get_contents($arguments['after']), true);
+    if (!is_array($before) || !is_array($after)) {
+        releaseBackportError('Invalid composer lockfile');
+    }
+    releaseBackportValidateLockScope($before, $after, $arguments['package']);
+    exit(0);
+}
+
+if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === __FILE__) {
+    releaseBackportError('Unknown command');
+}

--- a/scripts/backport-release.php
+++ b/scripts/backport-release.php
@@ -51,6 +51,19 @@ function releaseBackportAllocateVersion(string $current, array $tags): string
 
 function releaseBackportValidateLockScope(array $before, array $after, string $package): void
 {
+    $beforePackage = 0;
+    $afterPackage = 0;
+    foreach (['packages', 'packages-dev'] as $section) {
+        foreach (($before[$section] ?? []) as $entry) {
+            $beforePackage += (($entry['name'] ?? '') === $package) ? 1 : 0;
+        }
+        foreach (($after[$section] ?? []) as $entry) {
+            $afterPackage += (($entry['name'] ?? '') === $package) ? 1 : 0;
+        }
+    }
+    if ($beforePackage !== 1 || $afterPackage !== 1) {
+        releaseBackportError('Backport lock scope requires exactly one affected package entry');
+    }
     $normalize = static function (array $lock) use ($package): array {
         unset($lock['content-hash']);
         foreach (['packages', 'packages-dev'] as $section) {

--- a/scripts/release-community.php
+++ b/scripts/release-community.php
@@ -30,11 +30,15 @@ function releaseCommunityValidateContract(array $input): array
         $errors[] = 'release_type must be stable, rc, lts, or backport';
     }
 
-    foreach (['source_ref', 'release_version'] as $field) {
+    foreach (['source_ref', 'release_version', 'coordinator_correlation_id'] as $field) {
         $value = (string) ($input[$field] ?? '');
         if ($value === '' || !preg_match('/^[A-Za-z0-9][A-Za-z0-9._\/-]*$/', $value) || strpos($value, '..') !== false) {
             $errors[] = "{$field} is missing or unsafe";
         }
+    }
+
+    if (($input['package_manifest_run_id'] ?? '') !== '' && !preg_match('/^\d+$/', (string) $input['package_manifest_run_id'])) {
+        $errors[] = 'package_manifest_run_id is unsafe';
     }
 
     foreach (['allow_stable_fallback', 'allow_lts_fallback'] as $field) {
@@ -76,12 +80,49 @@ function releaseCommunityDirectRequirements(array $composer): array
 
 function releaseCommunityNormalizeTag(string $tag): string
 {
-    $tag = ltrim($tag, 'v');
+    $tag = preg_replace('/^v/', '', $tag) ?? $tag;
     if ($tag === '' || !preg_match('/^\d+(?:\.\d+){2,3}$/', $tag)) {
         releaseCommunityError("Unsupported stable package tag: {$tag}");
     }
 
     return $tag;
+}
+
+function releaseCommunityPackageResult(array $result, string $releaseType): array
+{
+    foreach (['package', 'repository', 'tag', 'version', 'commit', 'release_url', 'workflow_run_url'] as $field) {
+        if (!array_key_exists($field, $result) || !is_string($result[$field])) {
+            releaseCommunityError("Every package result requires {$field}");
+        }
+    }
+
+    $tag = $result['tag'];
+    $version = $result['version'];
+    $isDevelopment = (bool) preg_match('/^(?:dev-|dev\/|[^0-9]*release)/i', $tag);
+    if (!$isDevelopment) {
+        $version = releaseCommunityNormalizeTag($tag);
+        if (releaseCommunityNormalizeTag($result['version']) !== $version) {
+            releaseCommunityError("Package version does not match tag for {$result['package']}");
+        }
+    } elseif ($releaseType !== 'rc' && $releaseType !== 'lts') {
+        releaseCommunityError("Development tag {$tag} is not allowed for {$releaseType}");
+    } elseif ($version !== $tag) {
+        releaseCommunityError("Package version does not match development tag for {$result['package']}");
+    }
+
+    if ($result['repository'] !== $result['package']) {
+        releaseCommunityError("Package repository does not match {$result['package']}");
+    }
+    foreach (['release_url', 'workflow_run_url'] as $urlField) {
+        if ($result[$urlField] === '' || !preg_match('~^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(?:releases/tag|actions/runs)/[^\s]+$~', $result[$urlField])) {
+            releaseCommunityError("Invalid {$urlField} for {$result['package']}");
+        }
+    }
+    if (!preg_match('/^[a-f0-9]{7,64}$/i', $result['commit'])) {
+        releaseCommunityError("Invalid commit for {$result['package']}");
+    }
+
+    return ['tag' => $tag, 'version' => $version, 'metadata' => $result];
 }
 
 function releaseCommunityManifestResults(array $manifest): array
@@ -100,13 +141,7 @@ function releaseCommunityManifestResults(array $manifest): array
         if (!preg_match('/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/', $package)) {
             releaseCommunityError("Invalid package name: {$package}");
         }
-        $tag = (string) $result['tag'];
-        if (preg_match('/(?:dev|rc|alpha|beta|feature|fix|hotfix)/i', $tag)) {
-            $normalized[$package] = ['tag' => $tag, 'version' => $tag];
-            continue;
-        }
-        $version = releaseCommunityNormalizeTag($tag);
-        $normalized[$package] = ['tag' => $tag, 'version' => $version];
+        $normalized[$package] = releaseCommunityPackageResult($result, (string) ($manifest['release_type'] ?? 'stable'));
     }
 
     return $normalized;
@@ -115,6 +150,7 @@ function releaseCommunityManifestResults(array $manifest): array
 function releaseCommunityApplyManifest(array $composer, array $manifest, string $releaseType, bool $allowStableFallback, bool $allowLtsFallback, ?string $backportPackage = null): array
 {
     $requirements = releaseCommunityDirectRequirements($composer);
+    $manifest['release_type'] = $releaseType;
     $results = releaseCommunityManifestResults($manifest);
     $changed = [];
 
@@ -153,6 +189,123 @@ function releaseCommunityApplyManifest(array $composer, array $manifest, string 
     return ['composer' => $composer, 'changed' => $changed];
 }
 
+function releaseCommunityResolvePackages(array $composer, array $catalog, string $releaseType, string $sourceRef, bool $allowStableFallback, bool $allowLtsFallback, string $releaseVersion = ''): array
+{
+    $requirements = releaseCommunityDirectRequirements($composer);
+    $catalog = is_array($catalog['packages'] ?? null) ? $catalog['packages'] : $catalog;
+    if ($sourceRef === 'develop' && preg_match('/^(\d{4})[.-](\d{2})(?:\.\d+)?$/', $releaseVersion, $version)) {
+        $sourceRef = "release-{$version[1]}-{$version[2]}";
+    }
+    if (!preg_match('/^release-(\d{4}-\d{2})(-lts)?$/', $sourceRef, $line)) {
+        releaseCommunityError("Source ref is not a release line: {$sourceRef}");
+    }
+    $month = $line[1];
+    $results = [];
+    $fallbacks = [];
+    foreach (array_keys($requirements) as $package) {
+        if (!isset($catalog[$package]) || !is_array($catalog[$package])) {
+            releaseCommunityError("No package release data supplied for {$package}");
+        }
+        $data = $catalog[$package];
+        $repository = (string) ($data['repository'] ?? $package);
+        $branches = is_array($data['branches'] ?? null) ? $data['branches'] : [];
+        $tags = is_array($data['tags'] ?? null) ? $data['tags'] : [];
+        $branchNames = [];
+        if ($releaseType === 'lts') {
+            $branchNames = ["release-{$month}-lts", "dev-release-{$month}-lts", "release-{$month}", "dev-release-{$month}"];
+        } elseif ($releaseType === 'rc') {
+            $branchNames = ["dev-release-{$month}", "release-{$month}"];
+        }
+        if ($releaseType === 'stable') {
+            $stableCandidates = [];
+            foreach ($tags as $candidate) {
+                if (is_array($candidate) && isset($candidate['name'], $candidate['commit']) && !preg_match('/(?:dev|rc|alpha|beta|feature|fix|hotfix)/i', (string) $candidate['name'])) {
+                    try {
+                        releaseCommunityNormalizeTag((string) $candidate['name']);
+                        $stableCandidates[] = $candidate;
+                    } catch (Throwable) {
+                        continue;
+                    }
+                }
+            }
+            usort($stableCandidates, static fn (array $left, array $right): int => version_compare(
+                releaseCommunityNormalizeTag((string) $right['name']),
+                releaseCommunityNormalizeTag((string) $left['name'])
+            ));
+            $stable = $stableCandidates[0] ?? null;
+            if (!is_array($stable) || !isset($stable['name'], $stable['commit'])) {
+                releaseCommunityError("No stable package tag available for {$package}");
+            }
+            $tag = (string) $stable['name'];
+            $results[] = [
+                'package' => $package,
+                'repository' => $repository,
+                'tag' => $tag,
+                'version' => releaseCommunityNormalizeTag($tag),
+                'commit' => (string) $stable['commit'],
+                'release_url' => "https://github.com/{$repository}/releases/tag/{$tag}",
+                'workflow_run_url' => (string) ($data['workflow_run_url'] ?? ''),
+            ];
+            continue;
+        }
+        $selected = null;
+        foreach ($branchNames as $branchName) {
+            foreach ($branches as $branch) {
+                if (($branch['name'] ?? '') === $branchName) {
+                    $selected = [$branchName, (string) ($branch['commit'] ?? '')];
+                    break 2;
+                }
+            }
+        }
+        if ($selected !== null) {
+            if (!preg_match('/^[a-f0-9]{7,64}$/i', $selected[1])) {
+                releaseCommunityError("Invalid branch commit for {$package}");
+            }
+            $results[] = [
+                'package' => $package,
+                'repository' => $repository,
+                'tag' => $selected[0],
+                'version' => str_starts_with($selected[0], 'dev-') ? $selected[0] : 'dev-' . $selected[0],
+                'commit' => $selected[1],
+                'release_url' => "https://github.com/{$repository}/tree/{$selected[0]}",
+                'workflow_run_url' => (string) ($data['workflow_run_url'] ?? ''),
+            ];
+            continue;
+        }
+        $allowFallback = $releaseType === 'lts' ? $allowLtsFallback : $allowStableFallback;
+        if (!$allowFallback || $releaseType === 'stable') {
+            releaseCommunityError("No matching {$releaseType} release branch for {$package}");
+        }
+        $stable = null;
+        foreach ($tags as $candidate) {
+            if (is_array($candidate) && isset($candidate['name'], $candidate['commit']) && !preg_match('/(?:dev|rc|alpha|beta|feature|fix|hotfix)/i', (string) $candidate['name'])) {
+                $stable = $candidate;
+                break;
+            }
+        }
+        if (!is_array($stable) || !isset($stable['name'], $stable['commit'])) {
+            releaseCommunityError("No stable fallback available for {$package}");
+        }
+        $tag = (string) $stable['name'];
+        $version = releaseCommunityNormalizeTag($tag);
+        $results[] = [
+            'package' => $package,
+            'repository' => $repository,
+            'tag' => $tag,
+            'version' => $version,
+            'commit' => (string) $stable['commit'],
+            'release_url' => "https://github.com/{$repository}/releases/tag/{$tag}",
+            'workflow_run_url' => (string) ($data['workflow_run_url'] ?? ''),
+        ];
+        $fallbacks[] = [
+            'package' => $package,
+            'reason' => "No matching {$releaseType} release branch; used latest stable tag",
+            'tag' => $tag,
+        ];
+    }
+    return ['release_type' => $releaseType, 'package_results' => $results, 'fallbacks' => $fallbacks];
+}
+
 function releaseCommunityValidateScope(array $before, array $after, string $releaseType, ?string $backportPackage = null): void
 {
     $beforeRequire = releaseCommunityDirectRequirements($before);
@@ -166,6 +319,33 @@ function releaseCommunityValidateScope(array $before, array $after, string $rele
 
     if ($releaseType === 'backport' && ($changed !== [$backportPackage])) {
         releaseCommunityError('Backport changed an unexpected direct Composer requirement');
+    }
+}
+
+function releaseCommunityValidateLock(array $lock, array $manifest): void
+{
+    $locked = [];
+    foreach (['packages', 'packages-dev'] as $section) {
+        foreach ($lock[$section] ?? [] as $entry) {
+            if (isset($entry['name'])) {
+                $locked[$entry['name']] = $entry;
+            }
+        }
+    }
+    foreach ($manifest['package_results'] ?? [] as $result) {
+        $package = (string) ($result['package'] ?? '');
+        if (!isset($locked[$package])) {
+            continue;
+        }
+        $entry = $locked[$package];
+        $expectedVersion = (string) ($result['version'] ?? '');
+        $actualVersion = (string) ($entry['version'] ?? '');
+        if ($expectedVersion !== $actualVersion && ltrim($expectedVersion, 'v') !== ltrim($actualVersion, 'v')) {
+            releaseCommunityError("Composer lock version mismatch for {$package}");
+        }
+        if (($result['commit'] ?? '') !== '' && ($entry['source']['reference'] ?? '') !== $result['commit']) {
+            releaseCommunityError("Composer lock commit mismatch for {$package}");
+        }
     }
 }
 
@@ -213,6 +393,22 @@ if ($command === 'apply') {
     exit(0);
 }
 
+if ($command === 'resolve') {
+    $arguments = releaseCommunityArguments($argv);
+    $composer = releaseCommunityJson($arguments['composer']);
+    $catalog = releaseCommunityJson($arguments['catalog']);
+    releaseCommunityWriteJson($arguments['output'], releaseCommunityResolvePackages(
+        $composer,
+        $catalog,
+        $arguments['release_type'],
+        $arguments['source_ref'],
+        $arguments['allow_stable_fallback'] === 'true',
+        $arguments['allow_lts_fallback'] === 'true',
+        $arguments['release_version'] ?? ''
+    ));
+    exit(0);
+}
+
 if ($command === 'scope') {
     $arguments = releaseCommunityArguments($argv);
     releaseCommunityValidateScope(
@@ -224,8 +420,24 @@ if ($command === 'scope') {
     exit(0);
 }
 
+if ($command === 'lock-validate') {
+    $arguments = releaseCommunityArguments($argv);
+    releaseCommunityValidateLock(
+        releaseCommunityJson($arguments['lock']),
+        releaseCommunityJson($arguments['manifest'])
+    );
+    exit(0);
+}
+
 if ($command === 'result') {
     $arguments = releaseCommunityArguments($argv);
+    $packageResults = [];
+    if (($arguments['package_manifest'] ?? '') !== '' && is_file($arguments['package_manifest'])) {
+        $manifest = json_decode((string) file_get_contents($arguments['package_manifest']), true);
+        if (is_array($manifest) && is_array($manifest['package_results'] ?? null)) {
+            $packageResults = $manifest['package_results'];
+        }
+    }
     releaseCommunityWriteJson($arguments['output'], [
         'repository' => 'oat-sa/tao-community',
         'release_type' => $arguments['release_type'],
@@ -237,7 +449,9 @@ if ($command === 'result') {
         'tag' => $arguments['tag'] ?? '',
         'release_url' => $arguments['release_url'] ?? '',
         'workflow_run_url' => getenv('GITHUB_SERVER_URL') . '/' . getenv('GITHUB_REPOSITORY') . '/actions/runs/' . getenv('GITHUB_RUN_ID'),
+        'coordinator_correlation_id' => $arguments['coordinator_correlation_id'],
         'package_manifest' => $arguments['package_manifest'] ?? '',
+        'package_results' => $packageResults,
         'failure_reason' => $arguments['failure_reason'] ?? '',
     ]);
     exit(0);

--- a/scripts/release-community.php
+++ b/scripts/release-community.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+function releaseCommunityError(string $message): void
+{
+    fwrite(STDERR, $message . PHP_EOL);
+    exit(1);
+}
+
+function releaseCommunityJson(string $path): array
+{
+    if (!is_file($path)) {
+        releaseCommunityError("JSON file does not exist: {$path}");
+    }
+
+    $value = json_decode((string) file_get_contents($path), true);
+    if (!is_array($value)) {
+        releaseCommunityError("Invalid JSON object: {$path}");
+    }
+
+    return $value;
+}
+
+function releaseCommunityValidateContract(array $input): array
+{
+    $errors = [];
+    $releaseType = $input['release_type'] ?? '';
+    if (!in_array($releaseType, ['stable', 'rc', 'lts', 'backport'], true)) {
+        $errors[] = 'release_type must be stable, rc, lts, or backport';
+    }
+
+    foreach (['source_ref', 'release_version'] as $field) {
+        $value = (string) ($input[$field] ?? '');
+        if ($value === '' || !preg_match('/^[A-Za-z0-9][A-Za-z0-9._\/-]*$/', $value) || strpos($value, '..') !== false) {
+            $errors[] = "{$field} is missing or unsafe";
+        }
+    }
+
+    foreach (['allow_stable_fallback', 'allow_lts_fallback'] as $field) {
+        if (!in_array($input[$field] ?? null, [true, false, 'true', 'false', '0', '1', 0, 1], true)) {
+            $errors[] = "{$field} must be boolean";
+        }
+    }
+
+    if ($releaseType === 'backport') {
+        foreach (['backport_package', 'backport_source_pr', 'backport_target_branch'] as $field) {
+            $value = (string) ($input[$field] ?? '');
+            if ($value === '') {
+                $errors[] = "{$field} is required for backport releases";
+            }
+        }
+        if (isset($input['backport_package']) && !preg_match('/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/', (string) $input['backport_package'])) {
+            $errors[] = 'backport_package is unsafe';
+        }
+        if (isset($input['backport_target_branch']) && (!preg_match('/^[A-Za-z0-9][A-Za-z0-9._\/-]*$/', (string) $input['backport_target_branch']) || strpos((string) $input['backport_target_branch'], '..') !== false)) {
+            $errors[] = 'backport_target_branch is unsafe';
+        }
+        if (isset($input['backport_source_pr']) && !preg_match('/^(?:\d+|https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/pull\/\d+)$/', (string) $input['backport_source_pr'])) {
+            $errors[] = 'backport_source_pr is unsafe';
+        }
+    }
+
+    return $errors;
+}
+
+function releaseCommunityDirectRequirements(array $composer): array
+{
+    $requirements = $composer['require'] ?? null;
+    if (!is_array($requirements)) {
+        releaseCommunityError('composer.json has no require object');
+    }
+
+    return $requirements;
+}
+
+function releaseCommunityNormalizeTag(string $tag): string
+{
+    $tag = ltrim($tag, 'v');
+    if ($tag === '' || !preg_match('/^\d+(?:\.\d+){2,3}$/', $tag)) {
+        releaseCommunityError("Unsupported stable package tag: {$tag}");
+    }
+
+    return $tag;
+}
+
+function releaseCommunityManifestResults(array $manifest): array
+{
+    $results = $manifest['package_results'] ?? $manifest['packages'] ?? null;
+    if (!is_array($results)) {
+        releaseCommunityError('Package manifest must contain package_results');
+    }
+
+    $normalized = [];
+    foreach ($results as $result) {
+        if (!is_array($result) || !isset($result['package'], $result['tag'])) {
+            releaseCommunityError('Every package result requires package and tag');
+        }
+        $package = (string) $result['package'];
+        if (!preg_match('/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/', $package)) {
+            releaseCommunityError("Invalid package name: {$package}");
+        }
+        $tag = (string) $result['tag'];
+        if (preg_match('/(?:dev|rc|alpha|beta|feature|fix|hotfix)/i', $tag)) {
+            $normalized[$package] = ['tag' => $tag, 'version' => $tag];
+            continue;
+        }
+        $version = releaseCommunityNormalizeTag($tag);
+        $normalized[$package] = ['tag' => $tag, 'version' => $version];
+    }
+
+    return $normalized;
+}
+
+function releaseCommunityApplyManifest(array $composer, array $manifest, string $releaseType, bool $allowStableFallback, bool $allowLtsFallback, ?string $backportPackage = null): array
+{
+    $requirements = releaseCommunityDirectRequirements($composer);
+    $results = releaseCommunityManifestResults($manifest);
+    $changed = [];
+
+    foreach ($results as $package => $result) {
+        if (!array_key_exists($package, $requirements)) {
+            continue;
+        }
+
+        $tag = $result['tag'];
+        $isDevelopment = (bool) preg_match('/^(?:dev-|dev\/|[^0-9]*release)/i', $tag);
+        if ($releaseType === 'stable' || $releaseType === 'lts') {
+            if ($isDevelopment && !(($releaseType === 'stable' && $allowStableFallback) || ($releaseType === 'lts' && $allowLtsFallback))) {
+                releaseCommunityError("Development tag {$tag} is not allowed for {$releaseType}");
+            }
+            if ($isDevelopment) {
+                $fallbackTag = (string) ($result['fallback_tag'] ?? '');
+                if ($fallbackTag === '') {
+                    releaseCommunityError("Fallback for {$package} must provide a stable package tag");
+                }
+                $tag = releaseCommunityNormalizeTag($fallbackTag);
+            } else {
+                $tag = releaseCommunityNormalizeTag($tag);
+            }
+        }
+
+        if ($backportPackage !== null && $package !== $backportPackage) {
+            continue;
+        }
+        if ($requirements[$package] !== $tag) {
+            $requirements[$package] = $tag;
+            $changed[] = $package;
+        }
+    }
+
+    $composer['require'] = $requirements;
+    return ['composer' => $composer, 'changed' => $changed];
+}
+
+function releaseCommunityValidateScope(array $before, array $after, string $releaseType, ?string $backportPackage = null): void
+{
+    $beforeRequire = releaseCommunityDirectRequirements($before);
+    $afterRequire = releaseCommunityDirectRequirements($after);
+    $changed = [];
+    foreach (array_unique(array_merge(array_keys($beforeRequire), array_keys($afterRequire))) as $package) {
+        if (($beforeRequire[$package] ?? null) !== ($afterRequire[$package] ?? null)) {
+            $changed[] = $package;
+        }
+    }
+
+    if ($releaseType === 'backport' && ($changed !== [$backportPackage])) {
+        releaseCommunityError('Backport changed an unexpected direct Composer requirement');
+    }
+}
+
+function releaseCommunityWriteJson(string $path, array $value): void
+{
+    file_put_contents($path, json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL);
+}
+
+function releaseCommunityArguments(array $argv): array
+{
+    $arguments = [];
+    for ($index = 2; $index < count($argv); $index++) {
+        if (strpos($argv[$index], '--') !== 0 || !isset($argv[$index + 1])) {
+            releaseCommunityError('Arguments must use --name value');
+        }
+        $arguments[substr($argv[$index], 2)] = $argv[++$index];
+    }
+    return $arguments;
+}
+
+$command = $argv[1] ?? '';
+if ($command === 'validate') {
+    $errors = releaseCommunityValidateContract(releaseCommunityArguments($argv));
+    if ($errors !== []) {
+        releaseCommunityError(implode('; ', $errors));
+    }
+    exit(0);
+}
+
+if ($command === 'apply') {
+    $arguments = releaseCommunityArguments($argv);
+    $composerPath = $arguments['composer'] ?? 'composer.json';
+    $composer = releaseCommunityJson($composerPath);
+    $manifest = releaseCommunityJson($arguments['manifest']);
+    $result = releaseCommunityApplyManifest(
+        $composer,
+        $manifest,
+        $arguments['release_type'],
+        $arguments['allow_stable_fallback'] === 'true',
+        $arguments['allow_lts_fallback'] === 'true',
+        $arguments['backport_package'] ?? null
+    );
+    releaseCommunityWriteJson($composerPath, $result['composer']);
+    file_put_contents($arguments['output'], implode(PHP_EOL, $result['changed']) . PHP_EOL);
+    exit(0);
+}
+
+if ($command === 'scope') {
+    $arguments = releaseCommunityArguments($argv);
+    releaseCommunityValidateScope(
+        releaseCommunityJson($arguments['before']),
+        releaseCommunityJson($arguments['after']),
+        $arguments['release_type'],
+        $arguments['backport_package'] ?? null
+    );
+    exit(0);
+}
+
+if ($command === 'result') {
+    $arguments = releaseCommunityArguments($argv);
+    releaseCommunityWriteJson($arguments['output'], [
+        'repository' => 'oat-sa/tao-community',
+        'release_type' => $arguments['release_type'],
+        'source_ref' => $arguments['source_ref'],
+        'release_version' => $arguments['release_version'],
+        'status' => $arguments['status'],
+        'branch' => $arguments['branch'],
+        'pull_request_url' => $arguments['pull_request_url'] ?? '',
+        'tag' => $arguments['tag'] ?? '',
+        'release_url' => $arguments['release_url'] ?? '',
+        'workflow_run_url' => getenv('GITHUB_SERVER_URL') . '/' . getenv('GITHUB_REPOSITORY') . '/actions/runs/' . getenv('GITHUB_RUN_ID'),
+        'package_manifest' => $arguments['package_manifest'] ?? '',
+        'failure_reason' => $arguments['failure_reason'] ?? '',
+    ]);
+    exit(0);
+}
+
+if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === __FILE__) {
+    releaseCommunityError('Unknown command');
+}

--- a/scripts/release-community.php
+++ b/scripts/release-community.php
@@ -68,6 +68,11 @@ function releaseCommunityValidateContract(array $input): array
     return $errors;
 }
 
+function releaseCommunityBoolean(mixed $value): bool
+{
+    return in_array($value, [true, 'true', '1', 1], true);
+}
+
 function releaseCommunityDirectRequirements(array $composer): array
 {
     $requirements = $composer['require'] ?? null;
@@ -110,11 +115,14 @@ function releaseCommunityPackageResult(array $result, string $releaseType): arra
         releaseCommunityError("Package version does not match development tag for {$result['package']}");
     }
 
-    if ($result['repository'] !== $result['package']) {
+    if (strcasecmp($result['repository'], $result['package']) !== 0) {
         releaseCommunityError("Package repository does not match {$result['package']}");
     }
     foreach (['release_url', 'workflow_run_url'] as $urlField) {
-        if ($result[$urlField] === '' || !preg_match('~^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(?:releases/tag|actions/runs)/[^\s]+$~', $result[$urlField])) {
+        $paths = $urlField === 'release_url' && $isDevelopment
+            ? '(?:releases/tag|tree)'
+            : ($urlField === 'release_url' ? 'releases/tag' : 'actions/runs');
+        if ($result[$urlField] === '' || !preg_match("~^https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/{$paths}/[^\\s]+$~", $result[$urlField])) {
             releaseCommunityError("Invalid {$urlField} for {$result['package']}");
         }
     }
@@ -141,7 +149,11 @@ function releaseCommunityManifestResults(array $manifest): array
         if (!preg_match('/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/', $package)) {
             releaseCommunityError("Invalid package name: {$package}");
         }
-        $normalized[$package] = releaseCommunityPackageResult($result, (string) ($manifest['release_type'] ?? 'stable'));
+        $normalizedResult = releaseCommunityPackageResult($result, (string) ($manifest['release_type'] ?? 'stable'));
+        if (isset($normalized[$package]) && $normalized[$package] !== $normalizedResult) {
+            releaseCommunityError("Conflicting package results for {$package}");
+        }
+        $normalized[$package] = $normalizedResult;
     }
 
     return $normalized;
@@ -161,8 +173,8 @@ function releaseCommunityApplyManifest(array $composer, array $manifest, string 
 
         $tag = $result['tag'];
         $isDevelopment = (bool) preg_match('/^(?:dev-|dev\/|[^0-9]*release)/i', $tag);
-        if ($releaseType === 'stable' || $releaseType === 'lts') {
-            if ($isDevelopment && !(($releaseType === 'stable' && $allowStableFallback) || ($releaseType === 'lts' && $allowLtsFallback))) {
+        if ($releaseType === 'stable') {
+            if ($isDevelopment && !$allowStableFallback) {
                 releaseCommunityError("Development tag {$tag} is not allowed for {$releaseType}");
             }
             if ($isDevelopment) {
@@ -174,6 +186,8 @@ function releaseCommunityApplyManifest(array $composer, array $manifest, string 
             } else {
                 $tag = releaseCommunityNormalizeTag($tag);
             }
+        } elseif ($releaseType === 'lts' && $isDevelopment) {
+            $tag = $result['version'];
         }
 
         if ($backportPackage !== null && $package !== $backportPackage) {
@@ -212,7 +226,7 @@ function releaseCommunityResolvePackages(array $composer, array $catalog, string
         $tags = is_array($data['tags'] ?? null) ? $data['tags'] : [];
         $branchNames = [];
         if ($releaseType === 'lts') {
-            $branchNames = ["release-{$month}-lts", "dev-release-{$month}-lts", "release-{$month}", "dev-release-{$month}"];
+            $branchNames = ["release-{$month}-lts", "dev-release-{$month}-lts"];
         } elseif ($releaseType === 'rc') {
             $branchNames = ["dev-release-{$month}", "release-{$month}"];
         }
@@ -237,6 +251,10 @@ function releaseCommunityResolvePackages(array $composer, array $catalog, string
                 releaseCommunityError("No stable package tag available for {$package}");
             }
             $tag = (string) $stable['name'];
+            $workflowUrl = (string) (($data['workflow_runs'] ?? [])[(string) $stable['commit']] ?? '');
+            if ($workflowUrl === '') {
+                releaseCommunityError("No successful extension workflow run found for {$package}");
+            }
             $results[] = [
                 'package' => $package,
                 'repository' => $repository,
@@ -244,7 +262,7 @@ function releaseCommunityResolvePackages(array $composer, array $catalog, string
                 'version' => releaseCommunityNormalizeTag($tag),
                 'commit' => (string) $stable['commit'],
                 'release_url' => "https://github.com/{$repository}/releases/tag/{$tag}",
-                'workflow_run_url' => (string) ($data['workflow_run_url'] ?? ''),
+                'workflow_run_url' => $workflowUrl,
             ];
             continue;
         }
@@ -261,28 +279,41 @@ function releaseCommunityResolvePackages(array $composer, array $catalog, string
             if (!preg_match('/^[a-f0-9]{7,64}$/i', $selected[1])) {
                 releaseCommunityError("Invalid branch commit for {$package}");
             }
+            $packageTag = str_starts_with($selected[0], 'dev-') ? $selected[0] : 'dev-' . $selected[0];
             $results[] = [
                 'package' => $package,
                 'repository' => $repository,
-                'tag' => $selected[0],
-                'version' => str_starts_with($selected[0], 'dev-') ? $selected[0] : 'dev-' . $selected[0],
+                'tag' => $packageTag,
+                'version' => $packageTag,
                 'commit' => $selected[1],
                 'release_url' => "https://github.com/{$repository}/tree/{$selected[0]}",
-                'workflow_run_url' => (string) ($data['workflow_run_url'] ?? ''),
+                'workflow_run_url' => (string) (($data['workflow_runs'] ?? [])[$selected[1]] ?? ''),
             ];
+            if ($results[array_key_last($results)]['workflow_run_url'] === '') {
+                releaseCommunityError("No successful extension workflow run found for {$package}");
+            }
             continue;
         }
         $allowFallback = $releaseType === 'lts' ? $allowLtsFallback : $allowStableFallback;
         if (!$allowFallback || $releaseType === 'stable') {
             releaseCommunityError("No matching {$releaseType} release branch for {$package}");
         }
-        $stable = null;
+        $stableCandidates = [];
         foreach ($tags as $candidate) {
             if (is_array($candidate) && isset($candidate['name'], $candidate['commit']) && !preg_match('/(?:dev|rc|alpha|beta|feature|fix|hotfix)/i', (string) $candidate['name'])) {
-                $stable = $candidate;
-                break;
+                try {
+                    releaseCommunityNormalizeTag((string) $candidate['name']);
+                    $stableCandidates[] = $candidate;
+                } catch (Throwable) {
+                    continue;
+                }
             }
         }
+        usort($stableCandidates, static fn (array $left, array $right): int => version_compare(
+            releaseCommunityNormalizeTag((string) $right['name']),
+            releaseCommunityNormalizeTag((string) $left['name'])
+        ));
+        $stable = $stableCandidates[0] ?? null;
         if (!is_array($stable) || !isset($stable['name'], $stable['commit'])) {
             releaseCommunityError("No stable fallback available for {$package}");
         }
@@ -295,8 +326,11 @@ function releaseCommunityResolvePackages(array $composer, array $catalog, string
             'version' => $version,
             'commit' => (string) $stable['commit'],
             'release_url' => "https://github.com/{$repository}/releases/tag/{$tag}",
-            'workflow_run_url' => (string) ($data['workflow_run_url'] ?? ''),
+            'workflow_run_url' => (string) (($data['workflow_runs'] ?? [])[(string) $stable['commit']] ?? ''),
         ];
+        if ($results[array_key_last($results)]['workflow_run_url'] === '') {
+            releaseCommunityError("No successful extension workflow run found for {$package}");
+        }
         $fallbacks[] = [
             'package' => $package,
             'reason' => "No matching {$releaseType} release branch; used latest stable tag",
@@ -384,8 +418,8 @@ if ($command === 'apply') {
         $composer,
         $manifest,
         $arguments['release_type'],
-        $arguments['allow_stable_fallback'] === 'true',
-        $arguments['allow_lts_fallback'] === 'true',
+        releaseCommunityBoolean($arguments['allow_stable_fallback'] ?? false),
+        releaseCommunityBoolean($arguments['allow_lts_fallback'] ?? false),
         $arguments['backport_package'] ?? null
     );
     releaseCommunityWriteJson($composerPath, $result['composer']);
@@ -402,8 +436,8 @@ if ($command === 'resolve') {
         $catalog,
         $arguments['release_type'],
         $arguments['source_ref'],
-        $arguments['allow_stable_fallback'] === 'true',
-        $arguments['allow_lts_fallback'] === 'true',
+        releaseCommunityBoolean($arguments['allow_stable_fallback'] ?? false),
+        releaseCommunityBoolean($arguments['allow_lts_fallback'] ?? false),
         $arguments['release_version'] ?? ''
     ));
     exit(0);
@@ -436,6 +470,8 @@ if ($command === 'result') {
         $manifest = json_decode((string) file_get_contents($arguments['package_manifest']), true);
         if (is_array($manifest) && is_array($manifest['package_results'] ?? null)) {
             $packageResults = $manifest['package_results'];
+        } elseif (($arguments['status'] ?? '') === 'success') {
+            releaseCommunityError("Unreadable package manifest: {$arguments['package_manifest']}");
         }
     }
     releaseCommunityWriteJson($arguments['output'], [

--- a/tests/backport-release-test.php
+++ b/tests/backport-release-test.php
@@ -32,6 +32,15 @@ releaseBackportValidateLockScope(
     ['content-hash' => 'after', 'packages' => [['name' => 'oat-sa/generis', 'version' => '15.19.3'], ['name' => 'oat-sa/other', 'version' => '1.0.0']]],
     'oat-sa/generis'
 );
+$beforePath = tempnam(sys_get_temp_dir(), 'lock-before-');
+$afterPath = tempnam(sys_get_temp_dir(), 'lock-after-');
+file_put_contents($beforePath, json_encode(['content-hash' => 'before', 'packages' => [['name' => 'oat-sa/generis', 'version' => '15.19.2'], ['name' => 'oat-sa/other', 'version' => '1.0.0']]]));
+file_put_contents($afterPath, json_encode(['content-hash' => 'after', 'packages' => [['name' => 'oat-sa/generis', 'version' => '15.19.3'], ['name' => 'oat-sa/other', 'version' => '1.0.1']]]));
+$command = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg(__DIR__ . '/../scripts/backport-release.php') . ' lock-scope --before ' . escapeshellarg($beforePath) . ' --after ' . escapeshellarg($afterPath) . ' --package oat-sa/generis';
+exec($command, $unusedOutput, $exitCode);
+backportTestAssert($exitCode !== 0, 'unrelated lock changes should be rejected');
+@unlink($beforePath);
+@unlink($afterPath);
 backportTestAssert(
     releaseBackportRepository(['packages' => [['name' => 'oat-sa/generis', 'source' => ['url' => 'https://github.com/oat-sa/generis.git']]]], 'oat-sa/generis') === 'oat-sa/generis',
     'lock metadata should resolve the package repository'

--- a/tests/backport-release-test.php
+++ b/tests/backport-release-test.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../scripts/backport-release.php';
+
+function backportTestAssert(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+backportTestAssert(
+    releaseBackportAllocateVersion('16.1.2', ['v16.1.2', '16.1.2.1']) === '16.1.3',
+    'free patch version should be selected'
+);
+backportTestAssert(
+    releaseBackportAllocateVersion('16.1.2', ['v16.1.3']) === '16.1.2.1',
+    'occupied patch should use the first free four-part version'
+);
+backportTestAssert(
+    releaseBackportAllocateVersion('16.1.2.1', ['v16.1.2.1']) === '16.1.2.2',
+    'four-part versions should increment their suffix'
+);
+backportTestAssert(
+    releaseBackportAllocateVersion('16.1.2.1', ['v16.1.2.2']) === '16.1.2.3',
+    'four-part version allocation should skip occupied results'
+);
+releaseBackportValidateLockScope(
+    ['content-hash' => 'before', 'packages' => [['name' => 'oat-sa/generis', 'version' => '15.19.2'], ['name' => 'oat-sa/other', 'version' => '1.0.0']]],
+    ['content-hash' => 'after', 'packages' => [['name' => 'oat-sa/generis', 'version' => '15.19.3'], ['name' => 'oat-sa/other', 'version' => '1.0.0']]],
+    'oat-sa/generis'
+);
+backportTestAssert(
+    releaseBackportRepository(['packages' => [['name' => 'oat-sa/generis', 'source' => ['url' => 'https://github.com/oat-sa/generis.git']]]], 'oat-sa/generis') === 'oat-sa/generis',
+    'lock metadata should resolve the package repository'
+);
+
+echo "backport-release tests passed\n";

--- a/tests/release-community-test.php
+++ b/tests/release-community-test.php
@@ -50,7 +50,13 @@ $resolverComposer = ['require' => ['oat-sa/generis' => '15.19.2']];
 $catalog = ['packages' => [
     'oat-sa/generis' => [
         'repository' => 'oat-sa/generis',
-        'workflow_run_url' => 'https://github.com/oat-sa/generis/actions/runs/4',
+        'workflow_runs' => [
+            str_repeat('0', 40) => 'https://github.com/oat-sa/generis/actions/runs/4',
+            str_repeat('d', 40) => 'https://github.com/oat-sa/generis/actions/runs/5',
+            str_repeat('e', 40) => 'https://github.com/oat-sa/generis/actions/runs/6',
+            str_repeat('f', 40) => 'https://github.com/oat-sa/generis/actions/runs/7',
+            str_repeat('1', 40) => 'https://github.com/oat-sa/generis/actions/runs/8',
+        ],
         'branches' => [
             ['name' => 'dev-release-2026-08', 'commit' => str_repeat('0', 40)],
             ['name' => 'release-2026-08', 'commit' => str_repeat('d', 40)],
@@ -63,7 +69,9 @@ $catalog = ['packages' => [
 $rc = releaseCommunityResolvePackages($resolverComposer, $catalog, 'rc', 'release-2026-08', false, false);
 testAssert($rc['package_results'][0]['tag'] === 'dev-release-2026-08', 'RC should prefer the development release branch');
 $lts = releaseCommunityResolvePackages($resolverComposer, $catalog, 'lts', 'release-2026-08-lts', false, false);
-testAssert($lts['package_results'][0]['tag'] === 'release-2026-08-lts', 'LTS should prefer the stable LTS branch');
+testAssert($lts['package_results'][0]['tag'] === 'dev-release-2026-08-lts', 'LTS should prefer the stable LTS branch as a Composer development version');
+$ltsApplied = releaseCommunityApplyManifest($resolverComposer, $lts, 'lts', false, false);
+testAssert($ltsApplied['composer']['require']['oat-sa/generis'] === 'dev-release-2026-08-lts', 'LTS branch results should be accepted by manifest application');
 $stable = releaseCommunityResolvePackages($resolverComposer, $catalog, 'stable', 'release-2026-08', false, false);
 testAssert($stable['package_results'][0]['tag'] === 'v15.19.4', 'stable should use the latest stable tag');
 $derived = releaseCommunityResolvePackages($resolverComposer, $catalog, 'rc', 'develop', false, false, '2026.08');
@@ -72,6 +80,13 @@ releaseCommunityValidateLock(
     ['packages' => [['name' => 'oat-sa/generis', 'version' => '15.19.3', 'source' => ['reference' => 'abc123']]]],
     ['package_results' => [['package' => 'oat-sa/generis', 'version' => '15.19.3', 'commit' => 'abc123']]]
 );
+$caseSensitiveRepository = releaseCommunityManifestResults(['package_results' => [[
+    'package' => 'oat-sa/generis', 'repository' => 'OAT-SA/Generis', 'tag' => 'v15.19.3', 'version' => '15.19.3',
+    'commit' => str_repeat('a', 40), 'release_url' => 'https://github.com/OAT-SA/Generis/releases/tag/v15.19.3',
+    'workflow_run_url' => 'https://github.com/OAT-SA/Generis/actions/runs/9',
+]]]);
+testAssert($caseSensitiveRepository['oat-sa/generis']['metadata']['repository'] === 'OAT-SA/Generis', 'GitHub repository casing should be accepted');
+testAssert(releaseCommunityBoolean('1') && !releaseCommunityBoolean('0'), 'boolean CLI values should be coerced consistently');
 
 $composerPath = tempnam(sys_get_temp_dir(), 'composer-');
 $manifestPath = tempnam(sys_get_temp_dir(), 'manifest-');

--- a/tests/release-community-test.php
+++ b/tests/release-community-test.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../scripts/release-community.php';
+
+function testAssert(bool $condition, string $message): void
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+$composer = ['require' => ['oat-sa/generis' => '15.19.2', 'oat-sa/tao-core' => '50.10.11']];
+$manifest = ['package_results' => [
+    ['package' => 'oat-sa/generis', 'tag' => 'v15.19.3'],
+    ['package' => 'oat-sa/not-direct', 'tag' => 'v1.0.0'],
+]];
+$result = releaseCommunityApplyManifest($composer, $manifest, 'stable', false, false);
+testAssert($result['composer']['require']['oat-sa/generis'] === '15.19.3', 'v prefix should be normalized');
+testAssert($result['composer']['require']['oat-sa/tao-core'] === '50.10.11', 'unlisted direct requirement must remain unchanged');
+testAssert(count($result['changed']) === 1, 'only direct packages should be changed');
+
+$errors = releaseCommunityValidateContract([
+    'release_type' => 'stable',
+    'source_ref' => 'release-2026-08',
+    'release_version' => '2026.08',
+    'allow_stable_fallback' => 'false',
+    'allow_lts_fallback' => 'false',
+]);
+testAssert($errors === [], 'valid normalized contract should pass');
+
+$errors = releaseCommunityValidateContract([
+    'release_type' => 'backport',
+    'source_ref' => '../unsafe',
+    'release_version' => '2026.08',
+    'allow_stable_fallback' => 'false',
+    'allow_lts_fallback' => 'false',
+]);
+testAssert(count($errors) === 4, 'backport and unsafe ref validation should report all missing fields');
+
+$backport = releaseCommunityApplyManifest($composer, ['package_results' => [
+    ['package' => 'oat-sa/generis', 'tag' => '15.19.3'],
+]], 'backport', false, false, 'oat-sa/generis');
+releaseCommunityValidateScope($composer, $backport['composer'], 'backport', 'oat-sa/generis');
+testAssert($backport['composer']['require']['oat-sa/generis'] === '15.19.3', 'backport should update the affected package');
+
+echo "release-community tests passed\n";

--- a/tests/release-community-test.php
+++ b/tests/release-community-test.php
@@ -13,8 +13,8 @@ function testAssert(bool $condition, string $message): void
 
 $composer = ['require' => ['oat-sa/generis' => '15.19.2', 'oat-sa/tao-core' => '50.10.11']];
 $manifest = ['package_results' => [
-    ['package' => 'oat-sa/generis', 'tag' => 'v15.19.3'],
-    ['package' => 'oat-sa/not-direct', 'tag' => 'v1.0.0'],
+    ['package' => 'oat-sa/generis', 'repository' => 'oat-sa/generis', 'tag' => 'v15.19.3', 'version' => '15.19.3', 'commit' => str_repeat('a', 40), 'release_url' => 'https://github.com/oat-sa/generis/releases/tag/v15.19.3', 'workflow_run_url' => 'https://github.com/oat-sa/generis/actions/runs/1'],
+    ['package' => 'oat-sa/not-direct', 'repository' => 'oat-sa/not-direct', 'tag' => 'v1.0.0', 'version' => '1.0.0', 'commit' => str_repeat('b', 40), 'release_url' => 'https://github.com/oat-sa/not-direct/releases/tag/v1.0.0', 'workflow_run_url' => 'https://github.com/oat-sa/not-direct/actions/runs/2'],
 ]];
 $result = releaseCommunityApplyManifest($composer, $manifest, 'stable', false, false);
 testAssert($result['composer']['require']['oat-sa/generis'] === '15.19.3', 'v prefix should be normalized');
@@ -25,6 +25,7 @@ $errors = releaseCommunityValidateContract([
     'release_type' => 'stable',
     'source_ref' => 'release-2026-08',
     'release_version' => '2026.08',
+    'coordinator_correlation_id' => 'corr-1',
     'allow_stable_fallback' => 'false',
     'allow_lts_fallback' => 'false',
 ]);
@@ -37,12 +38,51 @@ $errors = releaseCommunityValidateContract([
     'allow_stable_fallback' => 'false',
     'allow_lts_fallback' => 'false',
 ]);
-testAssert(count($errors) === 4, 'backport and unsafe ref validation should report all missing fields');
+testAssert(count($errors) === 5, 'backport and unsafe ref validation should report all missing fields');
 
 $backport = releaseCommunityApplyManifest($composer, ['package_results' => [
-    ['package' => 'oat-sa/generis', 'tag' => '15.19.3'],
+    ['package' => 'oat-sa/generis', 'repository' => 'oat-sa/generis', 'tag' => '15.19.3', 'version' => '15.19.3', 'commit' => str_repeat('c', 40), 'release_url' => 'https://github.com/oat-sa/generis/releases/tag/15.19.3', 'workflow_run_url' => 'https://github.com/oat-sa/generis/actions/runs/3'],
 ]], 'backport', false, false, 'oat-sa/generis');
 releaseCommunityValidateScope($composer, $backport['composer'], 'backport', 'oat-sa/generis');
 testAssert($backport['composer']['require']['oat-sa/generis'] === '15.19.3', 'backport should update the affected package');
+
+$resolverComposer = ['require' => ['oat-sa/generis' => '15.19.2']];
+$catalog = ['packages' => [
+    'oat-sa/generis' => [
+        'repository' => 'oat-sa/generis',
+        'workflow_run_url' => 'https://github.com/oat-sa/generis/actions/runs/4',
+        'branches' => [
+            ['name' => 'dev-release-2026-08', 'commit' => str_repeat('0', 40)],
+            ['name' => 'release-2026-08', 'commit' => str_repeat('d', 40)],
+            ['name' => 'dev-release-2026-08-lts', 'commit' => str_repeat('e', 40)],
+            ['name' => 'release-2026-08-lts', 'commit' => str_repeat('f', 40)],
+        ],
+        'tags' => [['name' => 'v15.19.4', 'commit' => str_repeat('1', 40)]],
+    ],
+]];
+$rc = releaseCommunityResolvePackages($resolverComposer, $catalog, 'rc', 'release-2026-08', false, false);
+testAssert($rc['package_results'][0]['tag'] === 'dev-release-2026-08', 'RC should prefer the development release branch');
+$lts = releaseCommunityResolvePackages($resolverComposer, $catalog, 'lts', 'release-2026-08-lts', false, false);
+testAssert($lts['package_results'][0]['tag'] === 'release-2026-08-lts', 'LTS should prefer the stable LTS branch');
+$stable = releaseCommunityResolvePackages($resolverComposer, $catalog, 'stable', 'release-2026-08', false, false);
+testAssert($stable['package_results'][0]['tag'] === 'v15.19.4', 'stable should use the latest stable tag');
+$derived = releaseCommunityResolvePackages($resolverComposer, $catalog, 'rc', 'develop', false, false, '2026.08');
+testAssert($derived['package_results'][0]['tag'] === 'dev-release-2026-08', 'develop should derive the release line from the release version');
+releaseCommunityValidateLock(
+    ['packages' => [['name' => 'oat-sa/generis', 'version' => '15.19.3', 'source' => ['reference' => 'abc123']]]],
+    ['package_results' => [['package' => 'oat-sa/generis', 'version' => '15.19.3', 'commit' => 'abc123']]]
+);
+
+$composerPath = tempnam(sys_get_temp_dir(), 'composer-');
+$manifestPath = tempnam(sys_get_temp_dir(), 'manifest-');
+$outputPath = tempnam(sys_get_temp_dir(), 'output-');
+file_put_contents($composerPath, json_encode($resolverComposer));
+file_put_contents($manifestPath, json_encode(['package_results' => [['package' => 'oat-sa/generis', 'tag' => 'v15.19.3']]]));
+$command = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg(__DIR__ . '/../scripts/release-community.php') . ' apply --composer ' . escapeshellarg($composerPath) . ' --manifest ' . escapeshellarg($manifestPath) . ' --release_type stable --allow_stable_fallback false --allow_lts_fallback false --output ' . escapeshellarg($outputPath);
+exec($command, $unusedOutput, $exitCode);
+testAssert($exitCode !== 0, 'incomplete package metadata should be rejected');
+@unlink($composerPath);
+@unlink($manifestPath);
+@unlink($outputPath);
 
 echo "release-community tests passed\n";


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-4495

## Summary
- Add the AUT-4495 tao-community release workflow
- Update direct Composer requirements and publish release-result artifacts
- Add package backport branch, cherry-pick, and extension release orchestration

## Verification
- PHP release and backport tests pass
- PHP syntax checks pass
- YAML parsing passes
- actionlint and shellcheck were unavailable locally