### PR TITLE
fix: backport Item QTI 32.10.0 for INF-512

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "oat-sa/extension-tao-community": "11.1.9",
     "oat-sa/extension-tao-funcacl": "7.4.11",
     "oat-sa/extension-tao-dac-simple": "10.0.1",
-    "oat-sa/extension-tao-itemqti": "32.9.0",
+    "oat-sa/extension-tao-itemqti": "32.10.0",
     "oat-sa/extension-tao-testqti": "50.8.1",
     "oat-sa/extension-tao-testtaker": "8.13.8",
     "oat-sa/extension-tao-group": "7.10.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "850ea203872bd80c4b10553fc945d481",
+    "content-hash": "a0698011d65019f69c856e883101dcee",
     "packages": [
         {
             "name": "brick/math",
@@ -4807,16 +4807,16 @@
         },
         {
             "name": "oat-sa/extension-tao-itemqti",
-            "version": "v32.9.0",
+            "version": "v32.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/extension-tao-itemqti.git",
-                "reference": "ca69117137c3821fe2d8bb478441f0693c5e0fa9"
+                "reference": "427b45e09751474953bb3f953a3082a58b4d95e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/ca69117137c3821fe2d8bb478441f0693c5e0fa9",
-                "reference": "ca69117137c3821fe2d8bb478441f0693c5e0fa9",
+                "url": "https://api.github.com/repos/oat-sa/extension-tao-itemqti/zipball/427b45e09751474953bb3f953a3082a58b4d95e5",
+                "reference": "427b45e09751474953bb3f953a3082a58b4d95e5",
                 "shasum": ""
             },
             "require": {
@@ -4894,9 +4894,9 @@
             "support": {
                 "forum": "http://forum.taotesting.com",
                 "issues": "http://forge.taotesting.com",
-                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v32.9.0"
+                "source": "https://github.com/oat-sa/extension-tao-itemqti/tree/v32.10.0"
             },
-            "time": "2026-07-30T11:27:54+00:00"
+            "time": "2026-07-31T11:44:15+00:00"
         },
         {
             "name": "oat-sa/extension-tao-itemqti-pci",


### PR DESCRIPTION
## Summary
- Bumps `oat-sa/extension-tao-itemqti` from `32.9.0` to `32.10.0` on `release-2026-08-lts`.
- Brings in the rebuilt `qti-runner.css` so INF-512 table ruby/underline padding rules are present at runtime (SCSS was already in 32.8+/32.9, but CSS was missing from the shipped bundle until 32.10.0).

## Context
- [INF-512](https://oat-sa.atlassian.net/browse/INF-512)
- Same bump as [tao-construct#295](https://github.com/oat-sa/tao-construct/pull/295) for the 2026.08 LTS line.

## Test plan
- [ ] Confirm consumers of `dev-release-2026-08-lts` / this lock pick up itemqti `32.10.0`
- [ ] On vertical-rl item with table cells containing ruby + `txt-wavy` / `txt-dashed` / `txt-underline`, verify ruby no longer overlaps cell borders
- [ ] Smoke-check item authoring/preview still loads

[INF-512]: https://oat-sa.atlassian.net/browse/INF-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ