### PR TITLE
fix: backport tao-core 55.0.1.13 for INF-529 INF-530

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "prefer-stable": true,
   "require": {
     "oat-sa/generis": "16.2.4",
-    "oat-sa/tao-core": "55.0.1.12",
+    "oat-sa/tao-core": "55.0.1.13",
     "oat-sa/extension-tao-community": "11.1.7",
     "oat-sa/extension-tao-funcacl": "7.4.10",
     "oat-sa/extension-tao-dac-simple": "9.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8f1196619c7b05fddadc20364f89673",
+    "content-hash": "46f47caae5982c66741eb17c7145fc91",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -6571,16 +6571,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v55.0.1.12",
+            "version": "v55.0.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "4d7b006d71cfff0642b16b2f3b6ba789b1b0da67"
+                "reference": "8dd1c8b189e5e9c8c9b9fdef5e9491e82a55a8a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/4d7b006d71cfff0642b16b2f3b6ba789b1b0da67",
-                "reference": "4d7b006d71cfff0642b16b2f3b6ba789b1b0da67",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/8dd1c8b189e5e9c8c9b9fdef5e9491e82a55a8a2",
+                "reference": "8dd1c8b189e5e9c8c9b9fdef5e9491e82a55a8a2",
                 "shasum": ""
             },
             "require": {
@@ -6681,9 +6681,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v55.0.1.12"
+                "source": "https://github.com/oat-sa/tao-core/tree/v55.0.1.13"
             },
-            "time": "2026-07-02T13:56:42+00:00"
+            "time": "2026-08-11T12:52:24+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",


### PR DESCRIPTION
## Summary
- Bumps `oat-sa/tao-core` from `55.0.1.12` to `55.0.1.13` on `release-2026.02.29` (from tag `2026.02.28`).
- Ships ruby navigation fix via `@oat-sa/tao-core-shared-libs@1.12.1` from [tao-core#4501](https://github.com/oat-sa/tao-core/pull/4501) / [tao-core#4499](https://github.com/oat-sa/tao-core/pull/4499).

## Context
- [INF-529](https://oat-sa.atlassian.net/browse/INF-529)
- [INF-530](https://oat-sa.atlassian.net/browse/INF-530)

## Test plan
- [ ] Consumers of this lock/release line resolve `oat-sa/tao-core` `55.0.1.13`
- [ ] Verify ruby navigation on an environment built from this branch
- [ ] Smoke-check affected authoring/delivery flows

[INF-529]: https://oat-sa.atlassian.net/browse/INF-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[INF-530]: https://oat-sa.atlassian.net/browse/INF-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ