### PR TITLE
fix: backport tao-core 56.7.3 for INF-581

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
   "prefer-stable": true,
   "require": {
     "oat-sa/generis": "17.1.2",
-    "oat-sa/tao-core": "56.7.2",
+    "oat-sa/tao-core": "56.7.3",
     "oat-sa/extension-tao-community": "11.1.9",
     "oat-sa/extension-tao-funcacl": "7.4.11",
     "oat-sa/extension-tao-dac-simple": "10.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "529ea0f0f390d1987a1632d811262b9b",
+    "content-hash": "d02dd34a90c81cda7870722457a8a543",
     "packages": [
         {
             "name": "brick/math",
@@ -6755,16 +6755,16 @@
         },
         {
             "name": "oat-sa/tao-core",
-            "version": "v56.7.2",
+            "version": "v56.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/tao-core.git",
-                "reference": "d02cc8aab0fedcf1c07a80cfe0e629fc3ce99973"
+                "reference": "d92f1985385dfdd2a9e41182f63eb36c9fe1ec79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/d02cc8aab0fedcf1c07a80cfe0e629fc3ce99973",
-                "reference": "d02cc8aab0fedcf1c07a80cfe0e629fc3ce99973",
+                "url": "https://api.github.com/repos/oat-sa/tao-core/zipball/d92f1985385dfdd2a9e41182f63eb36c9fe1ec79",
+                "reference": "d92f1985385dfdd2a9e41182f63eb36c9fe1ec79",
                 "shasum": ""
             },
             "require": {
@@ -6870,9 +6870,9 @@
             "support": {
                 "forum": "https://forum.taocloud.org",
                 "issues": "https://github.com/oat-sa/tao-core/issues",
-                "source": "https://github.com/oat-sa/tao-core/tree/v56.7.2"
+                "source": "https://github.com/oat-sa/tao-core/tree/v56.7.3"
             },
-            "time": "2026-07-06T15:25:50+00:00"
+            "time": "2026-09-10T10:41:38+00:00"
         },
         {
             "name": "open-telemetry/api",
@@ -13927,5 +13927,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary
- Bumps `oat-sa/tao-core` from `56.7.2` to `56.7.3` on `release-2026.08.4` (from tag `2026.08.3`).
- Ships INF-581 ruby/furigana last-child authoring fix via `@oat-sa/tao-core-shared-libs@1.12.1` from [tao-core#4538](https://github.com/oat-sa/tao-core/pull/4538) / tag `v56.7.3`.

## Context
- [INF-581](https://oat-sa.atlassian.net/browse/INF-581)

## Test plan
- [ ] Consumers of this lock/release line resolve `oat-sa/tao-core` `56.7.3`
- [ ] Confirm shared-libs / CKEditor revision includes the null-guard (`5c7646c80`)
- [ ] Repro INF-581: ruby as last child — toolbar usable, Save persists
- [ ] Tag `2026.08.4` after merge (release owner)

[INF-581]: https://oat-sa.atlassian.net/browse/INF-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the underlying TAO Core dependency to version 56.7.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->